### PR TITLE
Write_ReadInto PR Review Changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,8 @@ deploy:
 
 install:
   - pip install -r requirements.txt
-  - pip install pylint circuitpython-build-tools Sphinx sphinx-rtd-theme
+  - pip install --force-reinstall pylint==1.9.2
+  - pip install circuitpython-build-tools Sphinx sphinx-rtd-theme
 
 script:
   - pylint src/**/*.py

--- a/src/adafruit_blinka/microcontroller/raspi_23/spi.py
+++ b/src/adafruit_blinka/microcontroller/raspi_23/spi.py
@@ -71,8 +71,11 @@ class SPI:
     def write_readinto(self, buffer_out, buffer_in, out_start=0, out_end=None, in_start=0, in_end=None):
         if not buffer_out or not buffer_in:
             return
+        if out_end is None or in_end is None:
+            out_end = len(buffer_out)
+            in_end = len(buffer_in)
         if out_end - out_start != in_end - in_start:
-            raise RuntimeError
+            raise RuntimeError('Buffer slices must be of equal length.')
         try:
             self._spi.open(self._port, 0)
             try:
@@ -82,8 +85,8 @@ class SPI:
             self._spi.max_speed_hz = self.baudrate
             self._spi.mode = self.mode
             self._spi.bits_per_word = self.bits
-            data = self._spi.xfer(list(buffer_out))
-            for i in range(len(buffer_in)): # 'readinto' the given buffer
+            data = self._spi.xfer(list(buffer_out[out_start:out_end]))
+            for i in range(len(buffer_in[in_start:in_end])): # 'readinto' the given buffer
                 buffer_in[i] = data[i]
             self._spi.close()
         except FileNotFoundError as not_found:

--- a/src/adafruit_blinka/microcontroller/raspi_23/spi.py
+++ b/src/adafruit_blinka/microcontroller/raspi_23/spi.py
@@ -68,11 +68,13 @@ class SPI:
             print("Could not open SPI device - check if SPI is enabled in kernel!")
             raise
 
-    def write_readinto(self, buffer_out, buffer_in, out_start=0, out_end=None, in_start=0, in_end=None):
+    def write_readinto(self, buffer_out, buffer_in, out_start=0,
+                       out_end=None, in_start=0, in_end=None):
         if not buffer_out or not buffer_in:
             return
-        if out_end is None or in_end is None:
-            out_end = len(buffer_out)
+        if out_end is None:
+            out_end = len(buffer_out)        
+        if in_end is None:
             in_end = len(buffer_in)
         if out_end - out_start != in_end - in_start:
             raise RuntimeError('Buffer slices must be of equal length.')
@@ -85,9 +87,9 @@ class SPI:
             self._spi.max_speed_hz = self.baudrate
             self._spi.mode = self.mode
             self._spi.bits_per_word = self.bits
-            data = self._spi.xfer(list(buffer_out[out_start:out_end]))
-            for i in range(len(buffer_in[in_start:in_end])): # 'readinto' the given buffer
-                buffer_in[i] = data[i]
+            data = self._spi.xfer(list(buffer_out[out_start:out_end+1]))
+            for i in range((in_end - in_start)):
+                buffer_in[i+in_start] = data[i]
             self._spi.close()
         except FileNotFoundError as not_found:
             print("Could not open SPI device - check if SPI is enabled in kernel!")


### PR DESCRIPTION
**Adding requested changes from previous pr:**

 
> runtime error should have a message explaining what went wrong

`raise RuntimeError('Buffer slices must be of equal length.')`

> checks if in_end/out_end is none and have them set to the 'default' len(array)

```
        if out_end is None or in_end is None:
            out_end = len(buffer_out)
            in_end = len(buffer_in)
```

>  use the out_start & out_end ranges here to limit what is sent

`            data = self._spi.xfer(list(buffer_out[out_start:out_end]))
`


> use the in_start & in_end ranges here to put the data in the right section of the buffer_in array

`            for i in range(len(buffer_in[in_start:in_end])): # 'readinto' the given buffer
`