### PR TITLE
fix raspi spi access of mode constants (was missing a "self")

### DIFF
--- a/src/adafruit_blinka/microcontroller/raspi_23/spi.py
+++ b/src/adafruit_blinka/microcontroller/raspi_23/spi.py
@@ -19,9 +19,9 @@ class SPI:
                   firstbit=MSB, sck=None, mosi=None, miso=None):
         mode = 0
         if polarity:
-            mode |= CPOL
+            mode |= self.CPOL
         if phase:
-            mode |= CPHA
+            mode |= self.CPHA
 
         self.clock_pin = sck
         self.mosi_pin = mosi


### PR DESCRIPTION
Found this while testing the MAX31865:

```
(.env) $ python3 ./max31865_simpletest.py  
Traceback (most recent call last): 
  File "./max31865_simpletest.py", line 15, in <module> 
    sensor = adafruit_max31865.MAX31865(spi, cs) 
  File "/home/pi/blinkenlight/.env/lib/python3.5/site-packages/adafruit_max31865.py", line 105, in __init__ 
    config = self._read_u8(_MAX31865_CONFIG_REG) 
  File "/home/pi/blinkenlight/.env/lib/python3.5/site-packages/adafruit_max31865.py", line 119, in _read_u8 
    with self._device as device: 
  File "/home/pi/blinkenlight/.env/lib/python3.5/site-packages/adafruit_bus_device/spi_device.py", line 83, in __enter__ 
    phase=self.phase) 
  File "/home/pi/blinkenlight/.env/lib/python3.5/site-packages/busio.py", line 104, in configure 
    miso=Pin(self._pins[2].id) 
  File "/home/pi/blinkenlight/.env/lib/python3.5/site-packages/adafruit_blinka/microcontroller/raspi_23/spi.py", line 24, in init 
    mode |= CPHA 
NameError: name 'CPHA' is not defined
```

Seems to work with this commit.  Feedback appreciated.  Is it better style to use `SPI.CPOL` than `self.CPOL`?