### PR TITLE
runtimeerror msg using neopixel_write without sudo 

### DIFF
--- a/src/adafruit_blinka/microcontroller/raspi_23/neopixel.py
+++ b/src/adafruit_blinka/microcontroller/raspi_23/neopixel.py
@@ -50,6 +50,8 @@ def neopixel_write(gpio, buf):
         if resp != ws.WS2811_SUCCESS:
             message = ws.ws2811_get_return_t_str(resp)
             raise RuntimeError('ws2811_init failed with code {0} ({1})'.format(resp, message))
+        if resp == -5:
+            print("You'll need to prefix python with 'sudo' to use neopixel_write.")
         atexit.register(neopixel_cleanup)
 
     channel = ws.ws2811_channel_get(_led_strip, LED_CHANNEL)
@@ -68,6 +70,8 @@ def neopixel_write(gpio, buf):
     if resp != ws.WS2811_SUCCESS:
         message = ws.ws2811_get_return_t_str(resp)
         raise RuntimeError('ws2811_render failed with code {0} ({1})'.format(resp, message))
+    if resp == 5:
+        print("You'll need to prefix python with 'sudo' to use neopixel_write.")
     time.sleep(0.001 * ((len(buf)//100)+1))  # about 1ms per 100 bytes
 
 

--- a/src/adafruit_blinka/microcontroller/raspi_23/neopixel.py
+++ b/src/adafruit_blinka/microcontroller/raspi_23/neopixel.py
@@ -70,8 +70,6 @@ def neopixel_write(gpio, buf):
     if resp != ws.WS2811_SUCCESS:
         message = ws.ws2811_get_return_t_str(resp)
         raise RuntimeError('ws2811_render failed with code {0} ({1})'.format(resp, message))
-    if resp == 5:
-        print("You'll need to prefix python with 'sudo' to use neopixel_write.")
     time.sleep(0.001 * ((len(buf)//100)+1))  # about 1ms per 100 bytes
 
 

--- a/src/neopixel_write.py
+++ b/src/neopixel_write.py
@@ -21,4 +21,7 @@ else:
 
 def neopixel_write(gpio, buf):
     """Write buf out on the given DigitalInOut."""
-    return _neopixel.neopixel_write(gpio, buf)
+    try:
+      return _neopixel.neopixel_write(gpio, buf)
+    except RuntimeError:
+      print("You'll need to prefix python with 'sudo' to use neopixel_write.")

--- a/src/neopixel_write.py
+++ b/src/neopixel_write.py
@@ -21,7 +21,4 @@ else:
 
 def neopixel_write(gpio, buf):
     """Write buf out on the given DigitalInOut."""
-    try:
-      return _neopixel.neopixel_write(gpio, buf)
-    except RuntimeError:
-      print("You'll need to prefix python with 'sudo' to use neopixel_write.")
+    return _neopixel.neopixel_write(gpio, buf)


### PR DESCRIPTION
Calls to `neopixel_write` fail when python is not run as sudo with:
`RuntimeError: ws2811_init failed with code -5 (mmap() failed)`

Let's catch that error, send a message to users to alert them to prefix their script with `sudo`