### PR TITLE
add preliminary I2C bus support for the BeagleBone Black

### DIFF
--- a/src/adafruit_blinka/board/beaglebone_black.py
+++ b/src/adafruit_blinka/board/beaglebone_black.py
@@ -73,3 +73,23 @@ LED_USR0 = pin.USR0
 LED_USR1 = pin.USR1
 LED_USR2 = pin.USR2
 LED_USR3 = pin.USR3
+
+# I2C and SPI pins from:
+# src/adafruit_blinka/board/raspi_23.py
+# SDA = pin.SDA
+# SCL = pin.SCL
+# CE1 = pin.D7
+# CE0 = pin.D8
+# MISO = pin.D9
+# MOSI = pin.D10
+# SCLK = pin.D11
+# SCK = pin.D11
+# TXD = pin.D14
+# RXD = pin.D15
+# MISO_1 = pin.D19
+# MOSI_1 = pin.D20
+# SCLK_1 = pin.D21
+# SCK_1 = pin.D21
+
+SDA = pin.SDA
+SCL = pin.SCL

--- a/src/adafruit_blinka/microcontroller/beaglebone_black/pin.py
+++ b/src/adafruit_blinka/microcontroller/beaglebone_black/pin.py
@@ -129,6 +129,9 @@ USR1 = Pin('USR1')
 USR2 = Pin('USR2')
 USR3 = Pin('USR3')
 
+SCL = Pin('P9_19')
+SDA = Pin('P9_20')
+
 # ordered as spiId, sckId, mosiId, misoId
 spiPorts = ()
 
@@ -138,6 +141,6 @@ uartPorts = (
 )
 
 i2cPorts = (
-    (),
+    (1, SCL, SDA),
 )
 

--- a/src/board.py
+++ b/src/board.py
@@ -44,4 +44,5 @@ elif board_id == "beaglebone_black":
 elif "sphinx" in sys.modules:
     pass
 else:
+    print("board.py: board not supported")
     raise NotImplementedError("Board not supported")

--- a/src/board.py
+++ b/src/board.py
@@ -44,5 +44,4 @@ elif board_id == "beaglebone_black":
 elif "sphinx" in sys.modules:
     pass
 else:
-    print("board.py: board not supported")
     raise NotImplementedError("Board not supported")

--- a/src/busio.py
+++ b/src/busio.py
@@ -18,6 +18,8 @@ class I2C(Lockable):
         self.deinit()
         if board_id == "raspi_3" or board_id == "raspi_2":
             from adafruit_blinka.microcontroller.raspi_23.i2c import I2C as _I2C
+        if board_id == "beaglebone_black":
+            from adafruit_blinka.microcontroller.raspi_23.i2c import I2C as _I2C
         else:
             from machine import I2C as _I2C
         from microcontroller.pin import i2cPorts
@@ -72,6 +74,8 @@ class SPI(Lockable):
         self.deinit()
         if board_id == "raspi_3" or board_id == "raspi_2":
             from adafruit_blinka.microcontroller.raspi_23.spi import SPI as _SPI
+        elif board_id == "beaglebone_black":
+            from adafruit_blinka.microcontroller.beaglebone_black.spi import SPI as _SPI
         else:
             from machine import SPI as _SPI
         from microcontroller.pin import spiPorts
@@ -91,6 +95,9 @@ class SPI(Lockable):
         if board_id == "raspi_3" or board_id == "raspi_2":
             from adafruit_blinka.microcontroller.raspi_23.spi import SPI as _SPI
             from adafruit_blinka.microcontroller.raspi_23.pin import Pin
+        elif board_id == "beaglebone_black":
+            from adafruit_blinka.microcontroller.beaglebone_black.spi import SPI as _SPI
+            from adafruit_blinka.microcontroller.beaglebone_black.pin import Pin
         else:
             from machine import SPI as _SPI
             from machine import Pin

--- a/src/microcontroller/__init__.py
+++ b/src/microcontroller/__init__.py
@@ -30,6 +30,8 @@ elif platform == "stm32":
 elif platform == "linux":
     if board_id == "raspi_3" or board_id == "raspi_2":
         from adafruit_blinka.microcontroller.raspi_23 import *
+    elif board_id == "beaglebone_black":
+        from adafruit_blinka.microcontroller.beaglebone_black import *
     else:
         raise NotImplementedError("Board not supported:", board_id)
 else:

--- a/src/microcontroller/pin.py
+++ b/src/microcontroller/pin.py
@@ -12,6 +12,8 @@ elif agnostic.platform == "stm32":
 elif agnostic.platform == "linux":
     if agnostic.board_id == "raspi_3" or agnostic.board_id == "raspi_2":
         from adafruit_blinka.microcontroller.raspi_23.pin import *
+    elif agnostic.board_id == "beaglebone_black":
+        from adafruit_blinka.microcontroller.beaglebone_black.pin import *
     else:
         raise NotImplementedError("Board not supported: ", agnostic.board_id)
 else:


### PR DESCRIPTION
Add initial support for I2C bus on BeagleBone Black.

I developed these changes using an [Adafruit BME280 breakout board](https://www.adafruit.com/product/2652) wired up to P9.19 (SCL) and P9.20 (SDA) and the [Adafruit_CircuitPython_BME280 library](https://github.com/adafruit/Adafruit_CircuitPython_BME280)

```
debian@beaglebone:~/Adafruit_CircuitPython_BME280$ sudo python3 ./examples/bme280_simpletest.py 
board.py: board_id=beaglebone_black
adafruit_bus_device/i2c_device.py: __init__: i2c=<busio.I2C object at 0xb6a5bb10>
adafruit_bus_device/i2c_device.py: __init__: device_address=119
SKIP adafruit_bus_device/i2c_device.py: __init__: i2c.writeto(device_address, b'')

Temperature: 25.1 C
Humidity: 34.9 %
Pressure: 995.0 hPa
Altitude = 153.42 meters
```

Please note that this is just preliminary support. I2C support in Blinka on BeagleBone Black requires hard-coded workarounds in the following libraries.
* [Adafruit_CircuitPython_BusDevice](https://github.com/adafruit/Adafruit_CircuitPython_BusDevice)
* [Adafruit_Python_PureIO](https://github.com/adafruit/Adafruit_Python_PureIO)

I still need to resolve the root cause and find an acceptable solution.



