### PR TITLE
Add preliminary SPI support for BeagleBone Black

### DIFF
--- a/src/adafruit_blinka/board/beaglebone_black.py
+++ b/src/adafruit_blinka/board/beaglebone_black.py
@@ -104,3 +104,5 @@ CE0 = pin.CE0
 MOSI = pin.MOSI
 MISO = pin.MISO
 SCLK = pin.SCLK
+#CircuitPython naming convention for SPI Clock
+SCK = pin.SCK

--- a/src/adafruit_blinka/board/beaglebone_black.py
+++ b/src/adafruit_blinka/board/beaglebone_black.py
@@ -106,3 +106,12 @@ MISO = pin.MISO
 SCLK = pin.SCLK
 #CircuitPython naming convention for SPI Clock
 SCK = pin.SCK
+
+# SPI1 pins
+# http://beagleboard.org/static/images/cape-headers-spi.png
+CE1 = pin.CE1
+MOSI_1 = pin.MOSI_1
+MISO_1 = pin.MISO_1
+SCLK_1 = pin.SCLK_1
+#CircuitPython naming convention for SPI Clock
+SCK_1 = pin.SCK_1

--- a/src/adafruit_blinka/board/beaglebone_black.py
+++ b/src/adafruit_blinka/board/beaglebone_black.py
@@ -93,3 +93,14 @@ LED_USR3 = pin.USR3
 
 SDA = pin.SDA
 SCL = pin.SCL
+
+# Refer to header default pin modes
+# http://beagleboard.org/static/images/cape-headers.png
+# P9_17 (SPI0_CSO => CE0) enables peripheral device
+# P9_18 (SPI0_D1 => MOSI) outputs data to peripheral device
+# P9_21 (SPIO_DO => MISO) receives data from peripheral device
+# P9_22 (SPI0_SCLK => SCLK) outputs clock signal
+CE0 = pin.CE0
+MOSI = pin.MOSI
+MISO = pin.MISO
+SCLK = pin.SCLK

--- a/src/adafruit_blinka/microcontroller/beaglebone_black/pin.py
+++ b/src/adafruit_blinka/microcontroller/beaglebone_black/pin.py
@@ -151,13 +151,12 @@ CE0 = Pin('P9_17')
 MOSI = Pin('P9_18')
 MISO = Pin('P9_21')
 SCLK = Pin('P9_22')
+#CircuitPython naming convention for SPI Clock
+SCK = Pin('P9_22')
 
-# example from RPi:
-# spiPorts = ((0, SCLK, MOSI, MISO), (1, SCLK_1, MOSI_1, MISO_1))
 # ordered as spiId, sckId, mosiId, misoId
-spiPorts = (
-   (0, SCLK, MOSI, MISO)
-)
+#spiPorts = ((0, SCLK, MOSI, MISO), (1, SCLK_1, MOSI_1, MISO_1))
+spiPorts = ((0, SCLK, MOSI, MISO), (1, SCLK, MOSI, MISO))
 
 # ordered as uartId, txId, rxId
 uartPorts = (

--- a/src/adafruit_blinka/microcontroller/beaglebone_black/pin.py
+++ b/src/adafruit_blinka/microcontroller/beaglebone_black/pin.py
@@ -154,9 +154,38 @@ SCLK = Pin('P9_22')
 #CircuitPython naming convention for SPI Clock
 SCK = Pin('P9_22')
 
+# Pins for SPI1
+# refer to:
+# http://beagleboard.org/static/images/cape-headers-spi.png
+#
+# CE1 P9.28 SPI1_CS0
+# MISO_1 P9.29 SPI1_D0
+# MOSI_1 P9.30 SPI1_D1
+# SCLK_1 P9.31 SPI_SCLK
+#
+# SPI1 conflicts with HDMI Audio (McASP)
+#
+# Refer to:
+# https://elinux.org/Beagleboard:BeagleBoneBlack_Debian#U-Boot_Overlays
+#
+# To Disable HDMI AUDIO, uncomment this line in /boot/uEnv.txt:
+# disable_uboot_overlay_audio=1
+#
+# Set pin modes for SPI1 with:
+#
+# config-pin p9.28 spi1_cs
+# config-pin p9.29 spi1
+# config-pin p9.30 spi1
+# config-pin p9.31 spi_sclk
+CE1 = Pin('P9_28')
+MOSI_1 = Pin('P9_29')
+MISO_1 = Pin('P9_30')
+SCLK_1 = Pin('P9_31')
+#CircuitPython naming convention for SPI Clock
+SCK_1 = Pin('P9_31')
+
 # ordered as spiId, sckId, mosiId, misoId
-#spiPorts = ((0, SCLK, MOSI, MISO), (1, SCLK_1, MOSI_1, MISO_1))
-spiPorts = ((0, SCLK, MOSI, MISO), (1, SCLK, MOSI, MISO))
+spiPorts = ((0, SCLK, MOSI, MISO), (1, SCLK_1, MOSI_1, MISO_1))
 
 # ordered as uartId, txId, rxId
 uartPorts = (

--- a/src/adafruit_blinka/microcontroller/beaglebone_black/pin.py
+++ b/src/adafruit_blinka/microcontroller/beaglebone_black/pin.py
@@ -132,8 +132,32 @@ USR3 = Pin('USR3')
 SCL = Pin('P9_19')
 SDA = Pin('P9_20')
 
+# Refer to header default pin modes
+# http://beagleboard.org/static/images/cape-headers.png
+#
+# P9_17 (SPI0_CSO => CE0) enables peripheral device
+# P9_18 (SPI0_D1 => MOSI) outputs data to peripheral device
+# P9_21 (SPIO_DO => MISO) receives data from peripheral device
+# P9_22 (SPI0_SCLK => SCLK) outputs clock signal
+# 
+# Use config-pin to set pin mode for SPI pins
+# https://github.com/beagleboard/bb.org-overlays/tree/master/tools/beaglebone-universal-io
+# config-pin p9.17 spi_cs
+# config-pin p9.18 spi
+# config-pin p9.21 spi
+# config-pin p9.22 spi_sclk
+#
+CE0 = Pin('P9_17')
+MOSI = Pin('P9_18')
+MISO = Pin('P9_21')
+SCLK = Pin('P9_22')
+
+# example from RPi:
+# spiPorts = ((0, SCLK, MOSI, MISO), (1, SCLK_1, MOSI_1, MISO_1))
 # ordered as spiId, sckId, mosiId, misoId
-spiPorts = ()
+spiPorts = (
+   (0, SCLK, MOSI, MISO)
+)
 
 # ordered as uartId, txId, rxId
 uartPorts = (

--- a/src/busio.py
+++ b/src/busio.py
@@ -71,18 +71,26 @@ class I2C(Lockable):
 
 class SPI(Lockable):
     def __init__(self, clock, MOSI=None, MISO=None):
+        print("SPI(): __init()")
         self.deinit()
         if board_id == "raspi_3" or board_id == "raspi_2":
             from adafruit_blinka.microcontroller.raspi_23.spi import SPI as _SPI
         elif board_id == "beaglebone_black":
-            from adafruit_blinka.microcontroller.beaglebone_black.spi import SPI as _SPI
+            print("SPI(): beaglebone_black: from adafruit_blinka.microcontroller.raspi_23.spi import SPI as _SPI")
+            from adafruit_blinka.microcontroller.raspi_23.spi import SPI as _SPI
         else:
             from machine import SPI as _SPI
         from microcontroller.pin import spiPorts
+        print("spiPorts: {0}".format(spiPorts))
+        print("for:")
         for portId, portSck, portMosi, portMiso in spiPorts:
+            print(portId, portSck, portMosi, portMiso)
             if ((clock == portSck) and                   # Clock is required!
                 (MOSI == portMosi or MOSI == None) and   # But can do with just output
                 (MISO == portMiso or MISO == None)):      # Or just input
+                print("Line 91")
+                print(_SPI)
+                print(_SPI(portId))
                 self._spi = _SPI(portId)
                 self._pins = (portSck, portMosi, portMiso)
                 break
@@ -96,7 +104,8 @@ class SPI(Lockable):
             from adafruit_blinka.microcontroller.raspi_23.spi import SPI as _SPI
             from adafruit_blinka.microcontroller.raspi_23.pin import Pin
         elif board_id == "beaglebone_black":
-            from adafruit_blinka.microcontroller.beaglebone_black.spi import SPI as _SPI
+            # reuse the raspberry pi class as both boards use Linux spidev
+            from adafruit_blinka.microcontroller.raspi_23.spi import SPI as _SPI
             from adafruit_blinka.microcontroller.beaglebone_black.pin import Pin
         else:
             from machine import SPI as _SPI


### PR DESCRIPTION
FYI - THIS IS WORK IN PROGRESS.  ADDITIONAL COMMITS WILL BE ADDED TO THIS PR.

Refer to header default pin modes
http://beagleboard.org/static/images/cape-headers.png

P9_17 (SPI0_CSO => CE0) enables peripheral device
P9_18 (SPI0_D1 => MOSI) outputs data to peripheral device
P9_21 (SPIO_DO => MISO) receives data from peripheral device
P9_22 (SPI0_SCLK => SCLK) outputs clock signal

Use config-pin to set pin mode for SPI pins
https://github.com/beagleboard/bb.org-overlays/tree/master/tools/beaglebone-universal-io

config-pin p9.17 spi_cs
config-pin p9.18 spi
config-pin p9.21 spi
config-pin p9.22 spi_sclk