### PR TITLE
add RPi.GPIO to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Adafruit-GPIO
+RPi.GPIO
 rpi_ws281x>=4.0.0; platform_machine=='armv7l'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 Adafruit-GPIO
-RPi.GPIO
-rpi_ws281x>=4.0.0; platform_machine=='armv7l'
+RPi.GPIO; platform_machine=='armv7l' or platform_machine=='armv6l'
+rpi_ws281x>=4.0.0; platform_machine=='armv7l' or platform_machine=='armv6l'

--- a/setup.py
+++ b/setup.py
@@ -34,8 +34,8 @@ setup(
     py_modules=['bitbangio', 'board', 'busio', 'digitalio', 'micropython', 'neopixel_write'],
     install_requires=[
         'Adafruit-GPIO',
-        "RPi.GPIO; platform_machine=='armv7l' or platform_machine=='armv61'",
-        "rpi_ws281x>=4.0.0; platform_machine=='armv7l' or platform_machine=='armv61'"
+        "RPi.GPIO; platform_machine=='armv7l' or platform_machine=='armv6l'",
+        "rpi_ws281x>=4.0.0; platform_machine=='armv7l' or platform_machine=='armv6l'"
     ],
     license='MIT',
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,11 @@ setup(
     packages=find_packages("src"),
     # If your package is a single module, use this instead of 'packages':
     py_modules=['bitbangio', 'board', 'busio', 'digitalio', 'micropython', 'neopixel_write'],
-    install_requires=['Adafruit-GPIO', 'RPi.GPIO', "rpi_ws281x>=4.0.0; platform_machine=='armv7l'"],
+    install_requires=[
+        'Adafruit-GPIO',
+        "RPi.GPIO; platform_machine=='armv7l' or platform_machine=='armv61'",
+        "rpi_ws281x>=4.0.0; platform_machine=='armv7l' or platform_machine=='armv61'"
+    ],
     license='MIT',
     classifiers=[
         # Trove classifiers

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     packages=find_packages("src"),
     # If your package is a single module, use this instead of 'packages':
     py_modules=['bitbangio', 'board', 'busio', 'digitalio', 'micropython', 'neopixel_write'],
-    install_requires=['Adafruit-GPIO', "rpi_ws281x>=4.0.0; platform_machine=='armv7l'"],
+    install_requires=['Adafruit-GPIO', 'RPi.GPIO', "rpi_ws281x>=4.0.0; platform_machine=='armv7l'"],
     license='MIT',
     classifiers=[
         # Trove classifiers


### PR DESCRIPTION
We're looking to dispense with this, but in the meantime I think it's breaking a fair number of installs.