### PR TITLE
Change platform detect to use '/proc/device-tree/model' to detect board type and add new boards easily.

### DIFF
--- a/src/adafruit_blinka/agnostic/Platform.py
+++ b/src/adafruit_blinka/agnostic/Platform.py
@@ -28,7 +28,7 @@ RASPBERRY_PI     = 1
 BEAGLEBONE_BLACK = 2
 MINNOWBOARD      = 3
 ORANGEPIPC       = 4
-GIANTBOARD      = 5
+GIANTBOARD       = 5
 
 def platform_detect():
 	"""Detect if running on the Raspberry Pi or Beaglebone Black and return the

--- a/src/adafruit_blinka/agnostic/Platform.py
+++ b/src/adafruit_blinka/agnostic/Platform.py
@@ -1,0 +1,111 @@
+# Copyright (c) 2014 Adafruit Industries
+# Author: Tony DiCola
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import platform
+import re
+import os
+
+# Platform identification constants.
+UNKNOWN          = 0
+RASPBERRY_PI     = 1
+BEAGLEBONE_BLACK = 2
+MINNOWBOARD      = 3
+ORANGEPIPC       = 4
+
+def platform_detect():
+	"""Detect if running on the Raspberry Pi or Beaglebone Black and return the
+	platform type.  Will return RASPBERRY_PI, BEAGLEBONE_BLACK, or UNKNOWN."""
+	# Handle Raspberry Pi
+	pi = pi_version()
+	if pi is not None:
+		return RASPBERRY_PI
+
+	# Handle Beaglebone Black and other linux boards
+	# Find boards based on device tree model names
+	command = 'cat /proc/device-tree/model'
+	plat = os.popen(command).read().strip()
+
+	if plat.lower().find('beagle') > -1:
+		return BEAGLEBONE_BLACK
+	elif plat.lower().find('xunlong orange pi 2') > -1:
+		return ORANGEPIPC
+		
+	# Handle Minnowboard
+	# Assumption is that mraa is installed
+	try: 
+		import mraa 
+		if mraa.getPlatformName()=='MinnowBoard MAX':
+			return MINNOWBOARD
+	except ImportError:
+		pass
+
+	# Couldn't figure out the platform, just return unknown.
+	return UNKNOWN
+
+
+def pi_revision():
+    """Detect the revision number of a Raspberry Pi, useful for changing
+    functionality like default I2C bus based on revision."""
+    # Revision list available at: http://elinux.org/RPi_HardwareHistory#Board_Revision_History
+    with open('/proc/cpuinfo', 'r') as infile:
+        for line in infile:
+            # Match a line of the form "Revision : 0002" while ignoring extra
+            # info in front of the revsion (like 1000 when the Pi was over-volted).
+            match = re.match('Revision\s+:\s+.*(\w{4})$', line, flags=re.IGNORECASE)
+            if match and match.group(1) in ['0000', '0002', '0003']:
+                # Return revision 1 if revision ends with 0000, 0002 or 0003.
+                return 1
+            elif match:
+                # Assume revision 2 if revision ends with any other 4 chars.
+                return 2
+        # Couldn't find the revision, throw an exception.
+        raise RuntimeError('Could not determine Raspberry Pi revision.')
+
+
+def pi_version():
+    """Detect the version of the Raspberry Pi.  Returns either 1, 2 or
+    None depending on if it's a Raspberry Pi 1 (model A, B, A+, B+),
+    Raspberry Pi 2 (model B+), or not a Raspberry Pi.
+    """
+    # Check /proc/cpuinfo for the Hardware field value.
+    # 2708 is pi 1
+    # 2709 is pi 2
+    # 2835 is pi 3 on 4.9.x kernel
+    # Anything else is not a pi.
+    with open('/proc/cpuinfo', 'r') as infile:
+        cpuinfo = infile.read()
+    # Match a line like 'Hardware   : BCM2709'
+    match = re.search('^Hardware\s+:\s+(\w+)$', cpuinfo,
+                      flags=re.MULTILINE | re.IGNORECASE)
+    if not match:
+        # Couldn't find the hardware, assume it isn't a pi.
+        return None
+    if match.group(1) == 'BCM2708':
+        # Pi 1
+        return 1
+    elif match.group(1) == 'BCM2709':
+        # Pi 2
+        return 2
+    elif match.group(1) == 'BCM2835':
+        # Pi 3 / Pi on 4.9.x kernel
+        return 3
+    else:
+        # Something else, not a pi.
+        return None

--- a/src/adafruit_blinka/agnostic/Platform.py
+++ b/src/adafruit_blinka/agnostic/Platform.py
@@ -28,7 +28,7 @@ RASPBERRY_PI     = 1
 BEAGLEBONE_BLACK = 2
 MINNOWBOARD      = 3
 ORANGEPIPC       = 4
-GIANT_BOARD      = 5
+GIANTBOARD      = 5
 
 def platform_detect():
 	"""Detect if running on the Raspberry Pi or Beaglebone Black and return the
@@ -48,7 +48,7 @@ def platform_detect():
 	elif plat.lower().find('xunlong orange pi 2') > -1:
 		return ORANGEPIPC
 	elif plat.lower().find('giant board') > -1:
-		return GIANT_BOARD
+		return GIANTBOARD
 		
 	# Handle Minnowboard
 	# Assumption is that mraa is installed

--- a/src/adafruit_blinka/agnostic/Platform.py
+++ b/src/adafruit_blinka/agnostic/Platform.py
@@ -28,6 +28,7 @@ RASPBERRY_PI     = 1
 BEAGLEBONE_BLACK = 2
 MINNOWBOARD      = 3
 ORANGEPIPC       = 4
+GIANT_BOARD      = 5
 
 def platform_detect():
 	"""Detect if running on the Raspberry Pi or Beaglebone Black and return the
@@ -46,6 +47,8 @@ def platform_detect():
 		return BEAGLEBONE_BLACK
 	elif plat.lower().find('xunlong orange pi 2') > -1:
 		return ORANGEPIPC
+	elif plat.lower().find('giant board') > -1:
+		return GIANT_BOARD
 		
 	# Handle Minnowboard
 	# Assumption is that mraa is installed

--- a/src/adafruit_blinka/agnostic/__init__.py
+++ b/src/adafruit_blinka/agnostic/__init__.py
@@ -13,35 +13,27 @@ platform = sys.platform
 board_id = None
 
 if platform is not None:
-    if platform == "esp8266":  # TODO more conservative board-guessing
-        board_id = "feather_huzzah"
-    elif platform == "samd21":
-        board_id = "feather_m0_express"
-    elif platform == "pyboard":
-        platform = "stm32"
-        board_id = "pyboard"
-    elif platform == "linux":
-        import re
-        # we're going to redo the Platform detection, this is a terrible hack
-        # for now.
-        try:
-            # lets see if we're an armbian board
-            for line in open("/etc/armbian-release", 'r'):
-                #print(line)
-                m = re.search('BOARD=(.*)', line)
-                if m:
-                    board_id = m.group(1)
-        except:
-            from Adafruit_GPIO import Platform
-            if Platform.platform_detect() == Platform.RASPBERRY_PI:
-                if Platform.pi_version() == 1:
-                    board_id = "raspi_1"
-                elif Platform.pi_version() == 2:
-                    board_id = "raspi_2"
-                elif Platform.pi_version() == 3:
-                    board_id = "raspi_3"
-            elif Platform.platform_detect() == Platform.BEAGLEBONE_BLACK:
-                board_id = "beaglebone_black"
+	if platform == "esp8266":  # TODO more conservative board-guessing
+		board_id = "feather_huzzah"
+	elif platform == "samd21":
+		board_id = "feather_m0_express"
+	elif platform == "pyboard":
+		platform = "stm32"
+		board_id = "pyboard"
+	elif platform == "linux":
+		import Platform
+		if Platform.platform_detect() == Platform.RASPBERRY_PI:
+			if Platform.pi_version() == 1:
+				board_id = "raspi_1"
+			elif Platform.pi_version() == 2:
+				board_id = "raspi_2"
+			elif Platform.pi_version() == 3:
+				board_id = "raspi_3"
+		elif Platform.platform_detect() == Platform.BEAGLEBONE_BLACK:
+			board_id = "beaglebone_black"
+		elif Platform.platform_detect() == Platform.ORANGEPIPC:
+			board_id = "orangepipc"
+			
 
 implementation = sys.implementation.name
 if implementation == "micropython":

--- a/src/adafruit_blinka/agnostic/__init__.py
+++ b/src/adafruit_blinka/agnostic/__init__.py
@@ -33,6 +33,8 @@ if platform is not None:
 			board_id = "beaglebone_black"
 		elif Platform.platform_detect() == Platform.ORANGEPIPC:
 			board_id = "orangepipc"
+		elif Platform.platform_detect() == Platform.ORANGEPIPC:
+			board_id = "giant_board"
 			
 
 implementation = sys.implementation.name

--- a/src/adafruit_blinka/agnostic/__init__.py
+++ b/src/adafruit_blinka/agnostic/__init__.py
@@ -21,7 +21,7 @@ if platform is not None:
 		platform = "stm32"
 		board_id = "pyboard"
 	elif platform == "linux":
-		import Platform
+		from adafruit_blinka import Platform
 		if Platform.platform_detect() == Platform.RASPBERRY_PI:
 			if Platform.pi_version() == 1:
 				board_id = "raspi_1"

--- a/src/adafruit_blinka/agnostic/__init__.py
+++ b/src/adafruit_blinka/agnostic/__init__.py
@@ -33,8 +33,8 @@ if platform is not None:
 			board_id = "beaglebone_black"
 		elif Platform.platform_detect() == Platform.ORANGEPIPC:
 			board_id = "orangepipc"
-		elif Platform.platform_detect() == Platform.ORANGEPIPC:
-			board_id = "giant_board"
+		elif Platform.platform_detect() == Platform.GIANTBOARD:
+			board_id = "giantboard"
 			
 
 implementation = sys.implementation.name

--- a/src/adafruit_blinka/agnostic/__init__.py
+++ b/src/adafruit_blinka/agnostic/__init__.py
@@ -21,7 +21,7 @@ if platform is not None:
 		platform = "stm32"
 		board_id = "pyboard"
 	elif platform == "linux":
-		from adafruit_blinka import Platform
+		from adafruit_blinka.agnostic import Platform
 		if Platform.platform_detect() == Platform.RASPBERRY_PI:
 			if Platform.pi_version() == 1:
 				board_id = "raspi_1"

--- a/src/adafruit_blinka/board/giantboard.py
+++ b/src/adafruit_blinka/board/giantboard.py
@@ -1,0 +1,25 @@
+from adafruit_blinka.microcontroller.giantboard import pin
+
+PD23 = pin.PD23
+PD21 = pin.PD21
+PD20 = pin.PD20
+PD24 = pin.PD24
+PD22 = pin.PD22
+PD19 = pin.PD19
+
+SPI0_SCLK = pin.PA14
+SPI0_MOSI = pin.PA15
+SPI0_MISO = pin.PA16
+
+UART1_RX = pin.PD2
+UART1_TX = pin.PD3
+
+PD13 = pin.PD12
+PD31 = pin.PD31
+PB0 = pin.PB0
+PB7 = pin.PB7
+PB1 = pin.PB1
+PB5 = pin.PB5
+PB3 = pin.PB3
+TWI0_SCL = pin.PC0
+TWI0_SDA = pin.PB31

--- a/src/adafruit_blinka/board/giantboard.py
+++ b/src/adafruit_blinka/board/giantboard.py
@@ -1,4 +1,4 @@
-from adafruit_blinka.microcontroller.giantboard import pin
+from adafruit_blinka.microcontroller.sama5d2 import pin
 
 PD23 = pin.PD23
 PD21 = pin.PD21

--- a/src/adafruit_blinka/board/giantboard.py
+++ b/src/adafruit_blinka/board/giantboard.py
@@ -7,12 +7,12 @@ PD24 = pin.PD24
 PD22 = pin.PD22
 PD19 = pin.PD19
 
-SPI0_SCLK = pin.PA14
-SPI0_MOSI = pin.PA15
-SPI0_MISO = pin.PA16
+SCK = pin.PA14
+MOSI = pin.PA15
+MISO = pin.PA16
 
-UART1_RX = pin.PD2
-UART1_TX = pin.PD3
+RX = pin.PD2
+TX = pin.PD3
 
 PD13 = pin.PD12
 PD31 = pin.PD31
@@ -21,5 +21,6 @@ PB7 = pin.PB7
 PB1 = pin.PB1
 PB5 = pin.PB5
 PB3 = pin.PB3
-TWI0_SCL = pin.PC0
-TWI0_SDA = pin.PB31
+
+SCL = pin.PC0
+SDA = pin.PB31

--- a/src/adafruit_blinka/board/giantboard.py
+++ b/src/adafruit_blinka/board/giantboard.py
@@ -7,14 +7,20 @@ PD24 = pin.PD24
 PD22 = pin.PD22
 PD19 = pin.PD19
 
+PA14 = pin.PA14
 SCK = pin.PA14
+SCLK = pin.PA14
+PA15 = pin.PA15
 MOSI = pin.PA15
+PA16 = pin.PA16
 MISO = pin.PA16
 
+PD2 = pin.PD2
 RX = pin.PD2
+PD3 = pin.PD3
 TX = pin.PD3
 
-PD13 = pin.PD12
+PD13 = pin.PD13
 PD31 = pin.PD31
 PB0 = pin.PB0
 PB7 = pin.PB7
@@ -22,5 +28,7 @@ PB1 = pin.PB1
 PB5 = pin.PB5
 PB3 = pin.PB3
 
+PC0 = pin.PC0
 SCL = pin.PC0
+PB31 = pin.PB31
 SDA = pin.PB31

--- a/src/adafruit_blinka/microcontroller/giant_board/pin.py
+++ b/src/adafruit_blinka/microcontroller/giant_board/pin.py
@@ -1,0 +1,31 @@
+from adafruit_blinka.microcontroller.generic_linux.libgpiod_pin import Pin
+
+PD23 = Pin(119) #AD4
+PD21 = Pin(117) #AD2
+PD20 = Pin(116) #AD1
+PD24 = Pin(120) #AD5
+PD22 = Pin(118) #AD3
+PD19 = Pin(115) #AD0
+
+SPI0_SCLK = PA14
+SPI0_MOSI = PA15
+SPI0_MISO = PA16
+
+UART1_RX = PD2
+UART1_TX = PD3
+
+PD13 = Pin(109)
+PD31 = Pin(128)
+PB0 = Pin(32)
+PB7 = Pin(38)
+PB1 = Pin(33)
+PB5 = Pin(37)
+PB3 = Pin(35)
+TWI0_SCL = PC0
+TWI0_SDA = PB31
+
+i2cPorts = ( (0, TWI0_SCL, TWI0_SDA), )
+# ordered as spiId, sckId, mosiId, misoId
+spiPorts = ( (0, SPI0_SCLK, SPI0_MOSI, SPI0_MISO), )
+# ordered as uartId, txId, rxId
+uartPorts = ( (3, UART1_TX, UART1_RX), )

--- a/src/adafruit_blinka/microcontroller/sama5d2/pin.py
+++ b/src/adafruit_blinka/microcontroller/sama5d2/pin.py
@@ -7,12 +7,12 @@ PD24 = Pin(120)
 PD22 = Pin(118)
 PD19 = Pin(115)
 
-SPI0_SCLK = Pin(14)
-SPI0_MOSI = Pin(15)
-SPI0_MISO = Pin(16)
+SPI0_SCLK = PA14
+SPI0_MOSI = PA15
+SPI0_MISO = PA16
 
-UART1_RX = Pin(98)
-UART1_TX = Pin(99)
+UART1_RX = PD2
+UART1_TX = PD3
 
 PD13 = Pin(109)
 PD31 = Pin(128)
@@ -21,8 +21,8 @@ PB7 = Pin(38)
 PB1 = Pin(33)
 PB5 = Pin(37)
 PB3 = Pin(35)
-TWI0_SCL = Pin(64)
-TWI0_SDA = Pin(63)
+TWI0_SCL = PC0
+TWI0_SDA = PB31
 
 i2cPorts = ( (0, TWI0_SCL, TWI0_SDA), )
 # ordered as spiId, sckId, mosiId, misoId

--- a/src/adafruit_blinka/microcontroller/sama5d2/pin.py
+++ b/src/adafruit_blinka/microcontroller/sama5d2/pin.py
@@ -1,11 +1,11 @@
 from adafruit_blinka.microcontroller.generic_linux.libgpiod_pin import Pin
 
-PD23 = Pin(119) #AD4
-PD21 = Pin(117) #AD2
-PD20 = Pin(116) #AD1
-PD24 = Pin(120) #AD5
-PD22 = Pin(118) #AD3
-PD19 = Pin(115) #AD0
+PD23 = Pin(119)
+PD21 = Pin(117)
+PD20 = Pin(116)
+PD24 = Pin(120)
+PD22 = Pin(118)
+PD19 = Pin(115)
 
 SPI0_SCLK = PA14
 SPI0_MOSI = PA15
@@ -28,4 +28,4 @@ i2cPorts = ( (0, TWI0_SCL, TWI0_SDA), )
 # ordered as spiId, sckId, mosiId, misoId
 spiPorts = ( (0, SPI0_SCLK, SPI0_MOSI, SPI0_MISO), )
 # ordered as uartId, txId, rxId
-uartPorts = ( (3, UART1_TX, UART1_RX), )
+uartPorts = ( (1, UART1_TX, UART1_RX), )

--- a/src/adafruit_blinka/microcontroller/sama5d2/pin.py
+++ b/src/adafruit_blinka/microcontroller/sama5d2/pin.py
@@ -7,21 +7,29 @@ PD24 = Pin(120)
 PD22 = Pin(118)
 PD19 = Pin(115)
 
+PA14 = Pin(14)
 SPI0_SCLK = PA14
+PA15 = Pin(15)
 SPI0_MOSI = PA15
+PA16 = Pin(16)
 SPI0_MISO = PA16
 
+PD2 = Pin(98)
 UART1_RX = PD2
+PD3 = Pin(99)
 UART1_TX = PD3
 
 PD13 = Pin(109)
-PD31 = Pin(128)
+PD31 = Pin(127)
 PB0 = Pin(32)
 PB7 = Pin(38)
 PB1 = Pin(33)
 PB5 = Pin(37)
 PB3 = Pin(35)
+
+PC0 = Pin(64)
 TWI0_SCL = PC0
+PB31 = Pin(63)
 TWI0_SDA = PB31
 
 i2cPorts = ( (0, TWI0_SCL, TWI0_SDA), )

--- a/src/adafruit_blinka/microcontroller/sama5d2/pin.py
+++ b/src/adafruit_blinka/microcontroller/sama5d2/pin.py
@@ -7,12 +7,12 @@ PD24 = Pin(120)
 PD22 = Pin(118)
 PD19 = Pin(115)
 
-SPI0_SCLK = PA14
-SPI0_MOSI = PA15
-SPI0_MISO = PA16
+SPI0_SCLK = Pin(14)
+SPI0_MOSI = Pin(15)
+SPI0_MISO = Pin(16)
 
-UART1_RX = PD2
-UART1_TX = PD3
+UART1_RX = Pin(98)
+UART1_TX = Pin(99)
 
 PD13 = Pin(109)
 PD31 = Pin(128)
@@ -21,8 +21,8 @@ PB7 = Pin(38)
 PB1 = Pin(33)
 PB5 = Pin(37)
 PB3 = Pin(35)
-TWI0_SCL = PC0
-TWI0_SDA = PB31
+TWI0_SCL = Pin(64)
+TWI0_SDA = Pin(63)
 
 i2cPorts = ( (0, TWI0_SCL, TWI0_SDA), )
 # ordered as spiId, sckId, mosiId, misoId

--- a/src/board.py
+++ b/src/board.py
@@ -43,6 +43,8 @@ elif board_id == "beaglebone_black":
     from adafruit_blinka.board.beaglebone_black import *
 elif board_id == "orangepipc":
     from adafruit_blinka.board.orangepipc import *
+elif board_id == "giantboard":
+    from adafruit_blinka.board.giantboard import *
 elif "sphinx" in sys.modules:
     pass
 else:

--- a/src/busio.py
+++ b/src/busio.py
@@ -16,7 +16,7 @@ class I2C(Lockable):
 
     def init(self, scl, sda, frequency):
         self.deinit()
-        if board_id in ("raspi_3", "raspi_2", "beaglebone_black", "orangepipc"):
+        if board_id in ("raspi_3", "raspi_2", "beaglebone_black", "orangepipc", "giantboard"):
             from adafruit_blinka.microcontroller.generic_linux.i2c import I2C as _I2C
         else:
             from machine import I2C as _I2C
@@ -70,7 +70,7 @@ class I2C(Lockable):
 class SPI(Lockable):
     def __init__(self, clock, MOSI=None, MISO=None):
         self.deinit()
-        if board_id in ("raspi_3", "raspi_2", "beaglebone_black", "orangepipc"):
+        if board_id in ("raspi_3", "raspi_2", "beaglebone_black", "orangepipc", "giantboard"):
             from adafruit_blinka.microcontroller.generic_linux.spi import SPI as _SPI
         else:
             from machine import SPI as _SPI

--- a/src/digitalio.py
+++ b/src/digitalio.py
@@ -14,6 +14,8 @@ elif board_id == "beaglebone_black":
     from adafruit_blinka.microcontroller.beaglebone_black.pin import Pin
 elif board_id == "orangepipc":
     from adafruit_blinka.microcontroller.allwinner_h3.pin import Pin
+elif board_id == "giantboard":
+    from adafruit_blinka.microcontroller.sama5d2.pin import Pin
 elif board_id == "pyboard":
     from machine import Pin
 from adafruit_blinka import Enum, ContextManaged

--- a/src/microcontroller/__init__.py
+++ b/src/microcontroller/__init__.py
@@ -34,7 +34,7 @@ elif platform == "linux":
         from adafruit_blinka.microcontroller.beaglebone_black import *
     elif board_id == "orangepipc":
         from adafruit_blinka.microcontroller.allwinner_h3 import *
-	elif board_id == "giant_board":
+	elif board_id == "giantboard":
         from adafruit_blinka.microcontroller.sama5d2 import *
     else:
         raise NotImplementedError("Board not supported:", board_id)

--- a/src/microcontroller/__init__.py
+++ b/src/microcontroller/__init__.py
@@ -35,7 +35,7 @@ elif platform == "linux":
     elif board_id == "orangepipc":
         from adafruit_blinka.microcontroller.allwinner_h3 import *
 	elif board_id == "giant_board":
-        from adafruit_blinka.microcontroller.giant_board import *
+        from adafruit_blinka.microcontroller.sama5d2 import *
     else:
         raise NotImplementedError("Board not supported:", board_id)
 else:

--- a/src/microcontroller/__init__.py
+++ b/src/microcontroller/__init__.py
@@ -34,7 +34,7 @@ elif platform == "linux":
         from adafruit_blinka.microcontroller.beaglebone_black import *
     elif board_id == "orangepipc":
         from adafruit_blinka.microcontroller.allwinner_h3 import *
-	elif board_id == "giantboard":
+    elif board_id == "giantboard":
         from adafruit_blinka.microcontroller.sama5d2 import *
     else:
         raise NotImplementedError("Board not supported:", board_id)

--- a/src/microcontroller/__init__.py
+++ b/src/microcontroller/__init__.py
@@ -34,6 +34,8 @@ elif platform == "linux":
         from adafruit_blinka.microcontroller.beaglebone_black import *
     elif board_id == "orangepipc":
         from adafruit_blinka.microcontroller.allwinner_h3 import *
+	elif board_id == "giant_board":
+        from adafruit_blinka.microcontroller.giant_board import *
     else:
         raise NotImplementedError("Board not supported:", board_id)
 else:

--- a/src/microcontroller/pin.py
+++ b/src/microcontroller/pin.py
@@ -15,7 +15,7 @@ elif agnostic.platform == "linux":
         from adafruit_blinka.microcontroller.beaglebone_black.pin import *
     elif agnostic.board_id == "orangepipc":
         from adafruit_blinka.microcontroller.allwinner_h3.pin import *
-	elif agnostic.board_id == "giantboard":
+    elif agnostic.board_id == "giantboard":
         from adafruit_blinka.microcontroller.sama5d2.pin import *
     else:
         raise NotImplementedError("Board not supported: ", agnostic.board_id)

--- a/src/microcontroller/pin.py
+++ b/src/microcontroller/pin.py
@@ -15,6 +15,8 @@ elif agnostic.platform == "linux":
         from adafruit_blinka.microcontroller.beaglebone_black.pin import *
     elif agnostic.board_id == "orangepipc":
         from adafruit_blinka.microcontroller.allwinner_h3.pin import *
+	elif agnostic.board_id == "giantboard":
+        from adafruit_blinka.microcontroller.sama5d2.pin import *
     else:
         raise NotImplementedError("Board not supported: ", agnostic.board_id)
 else:


### PR DESCRIPTION
This PR changes how boards are detected by using "cat /proc/device-tree/model" instead of reading the platform. This change checks for the device name determines the board based on that. This should allow for more boards to be added and detected for use with adafruit-blinka.

### What this does:

- Moves the Platform.py from Adafruit_Python_GPIO in to Adafruit_Blinka
- Changes how boards are detected based on device name in device tree.

### Tested on:

-  OSD3358 based board(pocketbeagle)
- SAMA5D2 based board
