### PR TITLE
Add board support files for Tritium H3

### DIFF
--- a/src/adafruit_blinka/board/tritium-h3.py
+++ b/src/adafruit_blinka/board/tritium-h3.py
@@ -1,0 +1,39 @@
+from adafruit_blinka.microcontroller.allwinner_h3 import pin
+
+PA12 = pin.PA12
+SDA = pin.PA12
+PA11 = pin.PA11
+SCL = pin.PA11
+PA2 = pin.PA2
+PA1 = pin.PA1
+PA0 = pin.PA0
+PA3 = pin.PA3
+PC0 = pin.PC0
+MOSI = pin.PC0
+PC1 = pin.PC1
+MISO = pin.PC1 
+PC2 = pin.PC2
+SCK = pin.PC2
+SCLK = pin.PC2
+PA19 = pin.PA19
+PA20 = pin.PA20
+PA21 = pin.PA21
+PA6 = pin.PA6
+PG10 = pin.PG10
+PA16 = pin.PA16
+
+PG6 = pin.PG6
+TX = pin.PG6
+PG7 = pin.PG7
+RX = pin.PG7
+PG11 = pin.PG11
+PG9 = pin.PG9
+PG8 = pin.PG8
+PA14 = pin.PA14
+PC3 = pin.PC3
+PA17 = pin.PA17
+PA18 = pin.PA18
+PA13 = pin.PA13
+PA15 = pin.PA15
+PG13 = pin.PG13
+PG12 = pin.PG12

--- a/src/adafruit_blinka/microcontroller/allwinner_h3/pin.py
+++ b/src/adafruit_blinka/microcontroller/allwinner_h3/pin.py
@@ -1,7 +1,9 @@
 from adafruit_blinka.microcontroller.generic_linux.libgpiod_pin import Pin
 
 PA0 = Pin(0)
+UART2_TX = PA0
 PA1 = Pin(1)
+UART2_RX = PA1
 PA2 = Pin(2)
 PA3 = Pin(3)
 PA6 = Pin(6)
@@ -17,6 +19,9 @@ PA13 = Pin(13)
 UART3_TX = PA13
 PA14 = Pin(14)
 UART3_RX = PA14
+PA15 = Pin(15)
+PA16 = Pin(16)
+PA17 = Pin(17)
 PA18 = Pin(18)
 PA19 = Pin(19)
 PA20 = Pin(20)
@@ -36,12 +41,20 @@ PC7 = Pin(71)
 PD14 = Pin(110)
 
 PG6 = Pin(198)
+UART1_TX = PG6
 PG7 = Pin(199)
+UART1_RX = PG7
 PG8 = Pin(200)
 PG9 = Pin(201)
+PG10 = Pin(202)
+PG11 = Pin(203)
+PG12 = Pin(204)
+PG13 = Pin(205)
+
 
 i2cPorts = ( (0, TWI0_SCL, TWI0_SDA), )
 # ordered as spiId, sckId, mosiId, misoId
 spiPorts = ( (0, SPI0_SCLK, SPI0_MOSI, SPI0_MISO), )
 # ordered as uartId, txId, rxId
-uartPorts = ( (3, UART3_TX, UART3_RX), )
+uartPorts = ( (1, UART1_TX, UART1_RX), 
+              (3, UART3_TX, UART3_RX), )

--- a/src/adafruit_blinka/microcontroller/allwinner_h3/pin.py
+++ b/src/adafruit_blinka/microcontroller/allwinner_h3/pin.py
@@ -56,5 +56,4 @@ i2cPorts = ( (0, TWI0_SCL, TWI0_SDA), )
 # ordered as spiId, sckId, mosiId, misoId
 spiPorts = ( (0, SPI0_SCLK, SPI0_MOSI, SPI0_MISO), )
 # ordered as uartId, txId, rxId
-uartPorts = ( (1, UART1_TX, UART1_RX), 
-              (3, UART3_TX, UART3_RX), )
+uartPorts = ( (3, UART3_TX, UART3_RX), )


### PR DESCRIPTION
This adds only the board file and extra needed pins to support the Libre Computer Tritium family: https://libre.computer/products/boards/all-h3-cc/ .  Obviously running on the board will not work with this patch alone, the various detects need put in place.

As the board detection is in flux I haven't pushed that part, and the UART port defined by the H3 file is OPi-PC specific, but will work if you have the pin map of the Tritium board handy, mentioned in https://github.com/adafruit/Adafruit_Blinka/issues/62

Armbian Board Name "tritium-h3"

