### PR TITLE
Add linux detect to busio.UART

### DIFF
--- a/src/busio.py
+++ b/src/busio.py
@@ -150,7 +150,7 @@ class UART(Lockable):
                  receiver_buffer_size=64,
                  flow=None):
         if detector.board.any_embedded_linux:
-            raise RuntimeError('busio.UART not supported on this platform.')
+            raise RuntimeError('busio.UART not supported on this platform. Please use pyserial instead.')
         else:
             from machine import UART as _UART
         from microcontroller.pin import uartPorts

--- a/src/busio.py
+++ b/src/busio.py
@@ -149,7 +149,10 @@ class UART(Lockable):
                  timeout=1000,
                  receiver_buffer_size=64,
                  flow=None):
-        from machine import UART as _UART
+        if detector.board.any_embedded_linux:
+            raise RuntimeError('busio.UART not supported on this platform.')
+        else:
+            from machine import UART as _UART
         from microcontroller.pin import uartPorts
 
         self.baudrate = baudrate


### PR DESCRIPTION
Fix for #74.

```python
pi@raspberrypi:~ $ python3
Python 3.5.3 (default, Sep 27 2018, 17:25:39) 
[GCC 6.3.0 20170516] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import board, busio
>>> uart = busio.UART(board.TXD, board.RXD)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/pi/Adafruit_Blinka/src/busio.py", line 153, in __init__
    raise RuntimeError('busio.UART not supported on this platform.')
RuntimeError: busio.UART not supported on this platform.
>>> 
```