### PR TITLE
first pass at adding correct i2c bus for original raspberry pi

### DIFF
--- a/src/adafruit_blinka/microcontroller/bcm283x/pin.py
+++ b/src/adafruit_blinka/microcontroller/bcm283x/pin.py
@@ -1,4 +1,6 @@
 import RPi.GPIO as GPIO
+from adafruit_blinka.agnostic import detector
+
 GPIO.setmode(GPIO.BCM)    # Use BCM pins D4 = GPIO #4
 GPIO.setwarnings(False)   # shh!
 
@@ -116,7 +118,12 @@ uartPorts = (
     (1, TXD, RXD),
 )
 
-i2cPorts = (
-    (1, SCL, SDA),
-)
-
+# Set correct i2c bus - original Pi used 0, subsequent models use 1:
+if detector.board.RASPBERRY_PI_B_REV1:
+    i2cPorts = (
+        (0, SCL, SDA),
+    )
+else:
+    i2cPorts = (
+        (1, SCL, SDA),
+    )


### PR DESCRIPTION
Per troubles here:

https://forums.adafruit.com/viewtopic.php?f=8&t=146375

It turns out the only Pi I have that's (maybe) old enough to reproduce this won't boot, but I _think_ this is what needs to happen, based on these lines:

https://github.com/adafruit/Adafruit_Blinka/blob/master/src/busio.py#L25

I have confirmed that this doesn't break anything on the next newest Pi model after the target one.