### PR TITLE
Ensure that the write_value passed into readinto is actually used

### DIFF
--- a/src/adafruit_blinka/microcontroller/generic_linux/spi.py
+++ b/src/adafruit_blinka/microcontroller/generic_linux/spi.py
@@ -50,7 +50,7 @@ class SPI:
             print("Could not open SPI device - check if SPI is enabled in kernel!")
             raise
 
-    def readinto(self, buf, start=0, end=None):
+    def readinto(self, buf, start=0, end=None, write_value=0):
         if not buf:
             return
         if end is None:
@@ -64,7 +64,7 @@ class SPI:
             self._spi.max_speed_hz = self.baudrate
             self._spi.mode = self.mode
             self._spi.bits_per_word = self.bits
-            data = self._spi.readbytes(end-start)
+            data = self._spi.xfer([write_value]*(end-start))
             for i in range(end-start):  # 'readinto' the given buffer
               buf[start+i] = data[i]
             self._spi.close()
@@ -77,7 +77,7 @@ class SPI:
         if not buffer_out or not buffer_in:
             return
         if out_end is None:
-            out_end = len(buffer_out)        
+            out_end = len(buffer_out)
         if in_end is None:
             in_end = len(buffer_in)
         if out_end - out_start != in_end - in_start:

--- a/src/busio.py
+++ b/src/busio.py
@@ -129,7 +129,7 @@ class SPI(Lockable):
         return self._spi.write(buf, start, end)
 
     def readinto(self, buf, start=0, end=None, write_value=0):
-        return self._spi.readinto(buf, start, end)
+        return self._spi.readinto(buf, start, end, write_value=write_value)
 
     def write_readinto(self, buffer_out, buffer_in,  out_start=0, out_end=None, in_start=0, in_end=None):
         return self._spi.write_readinto(buffer_out, buffer_in, out_start, out_end, in_start, in_end)


### PR DESCRIPTION
Have ported the micropython nRF24L01 driver over to circuitpython today, but found issues with the fact SPI `readinto` ignored the `write_value` parameter. It's advertised there, so it's frustrating it does nothing.

These changes ensure that value actually works. I've tested this on a pi zero successfully. Not sure how it effects boards where `machine.SPI` is used, rather than the `generic_linux.SPI` driver.