### PR TITLE
add I2C and SPI singletons for some drivers

### DIFF
--- a/src/board.py
+++ b/src/board.py
@@ -78,3 +78,13 @@ elif "sphinx" in sys.modules:
 
 else:
     raise NotImplementedError("Board not supported")
+
+def I2C():
+    """The singleton I2C interface"""
+    import busio
+    return busio.I2C(SCL, SDA)
+
+def SPI():
+    """The singleton SPI interface"""
+    import busio
+    return busio.SPI(SCLK, MOSI, MISO)


### PR DESCRIPTION
will default to the names we have for I2C and SPI default pins