### PR TITLE
Allow installation on Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
         "RPi.GPIO; platform_machine=='armv7l' or platform_machine=='armv6l'",
         "rpi_ws281x>=4.0.0; platform_machine=='armv7l' or platform_machine=='armv6l'",
         "spidev; sys_platform=='linux'",
-        "sysv_ipc"
+        "sysv_ipc; platform_system != 'Windows'"
     ],
     license='MIT',
     classifiers=[


### PR DESCRIPTION
While Blinka does not currently work on Microsoft Windows, it should be possible to install it as managing dependencies with pipenv requires that no install-time errors occur.

The current blocker to installation is a dependency on `sysv_ipc` which only works on POSIX-like operating systems. This change marks the dependency as being conditional on the install target not being Windows (this does not affect people running under cygwin or Windows Subsystem for Linux).

This does not add support for Windows, any attempt to use this code on Windows will result in exceptions being raised or non-functional code. This just makes it possible to manipulate pipenv environments that contain a transitive dependency on Blinka.

For more information on context see https://github.com/adafruit/Adafruit_Python_DHT/pull/113