### PR TITLE
do not set SPI_NO_CS bit when chip is AM3358 #104

### DIFF
--- a/src/adafruit_blinka/microcontroller/generic_linux/spi.py
+++ b/src/adafruit_blinka/microcontroller/generic_linux/spi.py
@@ -40,9 +40,6 @@ class SPI:
                 self._spi.no_cs = True  # this doesn't work but try anyways
             except AttributeError:
                 pass
-        else:
-            # TODO: remove this debug output
-            print("Adafruit_Blinka: generic_linux/spi.py: set_no_cs(): detected AM33XX, SKIP setting no_cs")
 
     def write(self, buf, start=0, end=None):
         if not buf:

--- a/src/adafruit_blinka/microcontroller/generic_linux/spi.py
+++ b/src/adafruit_blinka/microcontroller/generic_linux/spi.py
@@ -1,5 +1,6 @@
 import spidev
 import time
+from adafruit_blinka.agnostic import detector
 
 class SPI:
     MSB = 0
@@ -29,6 +30,19 @@ class SPI:
         self.baudrate = baudrate
         self.mode = mode
         self.bits = bits
+        self.chip = detector.chip
+
+    def set_no_cs(self):
+        # Linux SPI driver for AM33XX chip in BeagleBone and PocketBeagle
+        # does not support setting SPI_NO_CS mode bit (issue #104)
+        if not self.chip.AM33XX:
+            try:
+                self._spi.no_cs = True  # this doesn't work but try anyways
+            except AttributeError:
+                pass
+        else:
+            # TODO: remove this debug output
+            print("Adafruit_Blinka: generic_linux/spi.py: set_no_cs(): detected AM33XX, SKIP setting no_cs")
 
     def write(self, buf, start=0, end=None):
         if not buf:
@@ -37,10 +51,7 @@ class SPI:
             end = len(buf)
         try:
             self._spi.open(self._port, 0)
-            try:
-              self._spi.no_cs = True  # this doesn't work but try anyways
-            except AttributeError:
-              pass
+            self.set_no_cs()
             self._spi.max_speed_hz = self.baudrate
             self._spi.mode = self.mode
             self._spi.bits_per_word = self.bits
@@ -57,10 +68,7 @@ class SPI:
             end = len(buf)
         try:
             self._spi.open(self._port, 0)
-            try:
-              self._spi.no_cs = True  # this doesn't work but try anyways
-            except AttributeError:
-              pass
+            self.set_no_cs()
             self._spi.max_speed_hz = self.baudrate
             self._spi.mode = self.mode
             self._spi.bits_per_word = self.bits
@@ -84,10 +92,7 @@ class SPI:
             raise RuntimeError('Buffer slices must be of equal length.')
         try:
             self._spi.open(self._port, 0)
-            try:
-                self._spi.no_cs = True  # this doesn't work but try anyways
-            except AttributeError:
-                pass
+            self.set_no_cs()
             self._spi.max_speed_hz = self.baudrate
             self._spi.mode = self.mode
             self._spi.bits_per_word = self.bits


### PR DESCRIPTION
Avoid trying to set SPI_NO_CS mode bit when the chip is AM3358 as this
will always fail as Linux kernel driver omap2_mcspi does not support it.

This applies to the BeagleBone Black and PocketBeagle.