### PR TITLE
change SPI index for BeagleBone/PocketBeagle #106

### DIFF
--- a/src/adafruit_blinka/microcontroller/am335x/pin.py
+++ b/src/adafruit_blinka/microcontroller/am335x/pin.py
@@ -325,8 +325,8 @@ UART5_CTSn = Pin('UART5_CTSn')
 
 # ordered as spiId, sckId, mosiId, misoId
 spiPorts = (
-    (0, SPI0_SCLK, SPI0_D1, SPI0_D0),
-    (1, SPI1_SCLK, SPI1_D1, SPI1_D0),
+    (1, SPI0_SCLK, SPI0_D1, SPI0_D0),
+    (2, SPI1_SCLK, SPI1_D1, SPI1_D0),
 )
 
 # ordered as uartId, txId, rxId


### PR DESCRIPTION
Change SPI port index because SPI0 is `/dev/spidev1.x` and SPI1 is `/dev/spidev2.x` on both:
* the current recommended [BeagleBoard.org Debian image](http://beagleboard.org/latest-images): Debian 9.5 (Stretch) from 2018-10-07
* the newest [Debian 9.8 (Strecth) snapshot from 2019-04-07](https://elinux.org/Beagleboard:BeagleBoneBlack_Debian#Stretch_Snapshot_iot)

This change is to fix issue #106: inconsistent spidev index on AM335x-based boards like BeagleBone Black and PocketBeagle.