### PR TITLE
Google Coral support for the i2c, spi, and GPIO pins. 

### DIFF
--- a/src/adafruit_blinka/board/coral_edge_tpu.py
+++ b/src/adafruit_blinka/board/coral_edge_tpu.py
@@ -1,0 +1,22 @@
+"""Pin definitions for the Coral Edge TPU Dev board."""
+
+from adafruit_blinka.microcontroller.nxp_imx8m import pin
+
+SDA = pin.I2C2_SDA
+SCL = pin.I2C2_SCL
+
+
+GPIO_P13 = pin.GPIO6
+GPIO_P16 = pin.GPIO73
+GPIO_P18 = pin.GPIO138
+GPIO_P29 = pin.GPIO7
+GPIO_P31 = pin.GPIO8
+GPIO_P36 = pin.GPIO141
+GPIO_P37 = pin.GPIO77
+
+MISO = pin.ECSPI1_MISO
+MOSI = pin.ECSPI1_MOSI
+SCLK = pin.ECSPI1_SCLK
+SCK = pin.ECSPI1_SCLK
+SS0 = pin.ECSPI1_SS0
+

--- a/src/adafruit_blinka/microcontroller/generic_linux/libgpiod_pin.py
+++ b/src/adafruit_blinka/microcontroller/generic_linux/libgpiod_pin.py
@@ -18,10 +18,14 @@ class Pin:
     _value = LOW
     _mode = IN
 
-    def __init__(self, pin_number, gpiod_chipname="gpiochip0"):
-        self.id = int(pin_number)
-        # FIXME: Presumably this might vary by system:
-        self._chip = gpiod.Chip(gpiod_chipname, gpiod.Chip.OPEN_BY_NAME)
+    def __init__(self, pin_id):
+        self.id = pin_id
+        if type(pin_id) is tuple:
+            self._num = int(pin_id[1])
+            self._chip = gpiod.Chip(str(pin_id[0]), gpiod.Chip.OPEN_BY_NUMBER)
+        else:
+            self._num = int(pin_id)
+            self._chip = gpiod.Chip("gpiochip0", gpiod.Chip.OPEN_BY_NAME)
         self._line = None
 
     def __repr__(self):
@@ -32,8 +36,8 @@ class Pin:
 
     def init(self, mode=IN, pull=None):
         if not self._line:
-            self._line = self._chip.get_line(int(self.id))
-            #print("init line: ", int(self.id), self._line)
+            self._line = self._chip.get_line(int(self._num))
+            #print("init line: ", self.id, self._line)
 
         if mode != None:
             if mode == self.IN:

--- a/src/adafruit_blinka/microcontroller/generic_linux/spi.py
+++ b/src/adafruit_blinka/microcontroller/generic_linux/spi.py
@@ -35,7 +35,7 @@ class SPI:
     def set_no_cs(self):
         # Linux SPI driver for AM33XX chip in BeagleBone and PocketBeagle
         # does not support setting SPI_NO_CS mode bit (issue #104)
-        if not self.chip.AM33XX:
+        if not self.chip.AM33XX and not self.chip.IMX8MX:
             try:
                 self._spi.no_cs = True  # this doesn't work but try anyways
             except AttributeError:

--- a/src/adafruit_blinka/microcontroller/nxp_imx8m/pin.py
+++ b/src/adafruit_blinka/microcontroller/nxp_imx8m/pin.py
@@ -1,0 +1,29 @@
+from adafruit_blinka.microcontroller.generic_linux.libgpiod_pin import Pin
+
+I2C2_SCL = Pin(144) # GPIO5_IO16
+I2C2_SDA = Pin(145) # GPIO5_IO17
+
+I2C3_SCL = Pin(146) # GPIO5_IO18
+I2C3_SDA = Pin(147) # GPIO5_IO19
+
+
+GPIO6 = Pin((0, 6))     # GPIO1_IO6
+GPIO7 = Pin((0, 7))     # GPIO1_IO7
+GPIO8 = Pin((0, 8))     # GPIO1_IO8
+GPIO73 = Pin((2, 9))    # GPIO3_IO9
+GPIO77 = Pin((2, 13))   # GPIO3_IO13
+GPIO138 = Pin((4, 10))  # GPIO5_IO10 
+GPIO141 = Pin((4, 13))  # GPIO5_IO13
+
+ECSPI1_MISO = Pin(136) # GPIO5_IO8
+ECSPI1_MOSI = Pin(135) # GPIO5_IO7 
+ECSPI1_SCLK = Pin(134) # GPIO5_IO6
+ECSPI1_SS0 = Pin(133)  # GPIO5_IO9 
+
+
+i2cPorts = ( (1, I2C2_SCL, I2C2_SDA), (2, I2C3_SCL, I2C3_SDA),)
+# ordered as spiId, sckId, mosiId, misoId
+spiPorts = ( (32766, ECSPI1_SCLK, ECSPI1_MOSI, ECSPI1_MISO), )
+
+# UART1_TXD/RXD on /dev/ttymxc0
+# UART3_TXD/RXD not available (?)

--- a/src/board.py
+++ b/src/board.py
@@ -76,6 +76,9 @@ elif board_id == ap_board.JETSON_XAVIER:
 elif board_id == ap_board.JETSON_NANO:
     from adafruit_blinka.board.jetson_nano import *
 
+elif board_id == ap_board.CORAL_EDGE_TPU_DEV:
+    from adafruit_blinka.board.coral_edge_tpu import *
+
 elif "sphinx" in sys.modules:
     pass
 

--- a/src/busio.py
+++ b/src/busio.py
@@ -102,6 +102,9 @@ class SPI(Lockable):
         elif board_id == ap_board.GIANT_BOARD:
             from adafruit_blinka.microcontroller.sama5.pin import Pin
             from adafruit_blinka.microcontroller.generic_linux.spi import SPI as _SPI
+        elif board_id == ap_board.CORAL_EDGE_TPU_DEV:
+            from adafruit_blinka.microcontroller.nxp_imx8m.pin import Pin
+            from adafruit_blinka.microcontroller.generic_linux.spi import SPI as _SPI
         else:
             from machine import SPI as _SPI
             from machine import Pin

--- a/src/digitalio.py
+++ b/src/digitalio.py
@@ -25,6 +25,8 @@ elif detector.chip.T186:
     from adafruit_blinka.microcontroller.tegra.t186.pin import Pin
 elif detector.chip.T194:
     from adafruit_blinka.microcontroller.tegra.t194.pin import Pin
+elif detector.chip.IMX8MX:
+    from adafruit_blinka.microcontroller.nxp_imx8m.pin import Pin
 elif detector.chip.STM32:
     from machine import Pin
 from adafruit_blinka import Enum, ContextManaged

--- a/src/microcontroller/__init__.py
+++ b/src/microcontroller/__init__.py
@@ -42,5 +42,7 @@ elif chip_id == ap_chip.T186:
     from adafruit_blinka.microcontroller.tegra.t186 import *
 elif chip_id == ap_chip.T194:
     from adafruit_blinka.microcontroller.tegra.t194 import *
+elif chip_id == ap_chip.IMX8MX:
+    from adafruit_blinka.microcontroller.nxp_imx8m import *
 else:
     raise NotImplementedError("Microcontroller not supported:", chip_id)

--- a/src/microcontroller/pin.py
+++ b/src/microcontroller/pin.py
@@ -24,5 +24,7 @@ elif chip_id == ap_chip.T186:
     from adafruit_blinka.microcontroller.tegra.t186.pin import *
 elif chip_id == ap_chip.T194:
     from adafruit_blinka.microcontroller.tegra.t194.pin import *
+elif chip_id == ap_chip.IMX8MX:
+    from adafruit_blinka.microcontroller.nxp_imx8m.pin import *
 else:
     raise NotImplementedError("Microcontroller not supported: ", chip_id)


### PR DESCRIPTION
uart #3 not available and remaining pins are I2S or PWM