### PR TITLE
Update Giant Board alt pins names and add sysfs pwm support

### DIFF
--- a/src/adafruit_blinka/board/giantboard.py
+++ b/src/adafruit_blinka/board/giantboard.py
@@ -1,11 +1,17 @@
 from adafruit_blinka.microcontroller.sama5 import pin
 
 PD23 = pin.PD23
+AD4 = pin.PD23
 PD21 = pin.PD21
+AD2 = pin.PD21
 PD20 = pin.PD20
+AD1 = pin.PD20
 PD24 = pin.PD24
+AD5 = pin.PD24
 PD22 = pin.PD22
+AD3 = pin.PD22
 PD19 = pin.PD19
+AD0 = pin.PD19
 PA14 = pin.PA14
 SCK = pin.PA14
 SCLK = pin.PA14
@@ -21,9 +27,13 @@ TX = pin.PD3
 PD13 = pin.PD13
 PD31 = pin.PD31
 PB0 = pin.PB0
+PWM1 = pin.PB0
 PB7 = pin.PB7
+PWM3 = pin.PB7
 PB1 = pin.PB1
+PWML1 = pin.PB1
 PB5 = pin.PB5
+PWM2 = pin.PB5
 PB3 = pin.PB3
 PC0 = pin.PC0
 SCL = pin.PC0

--- a/src/adafruit_blinka/microcontroller/generic_linux/sysfs_pwmout.py
+++ b/src/adafruit_blinka/microcontroller/generic_linux/sysfs_pwmout.py
@@ -90,12 +90,12 @@ class PWMOut(object):
         except IOError as e:
             raise PWMError(e.errno, "Exporting PWM pin: " + e.strerror)
 
-        #self._set_enabled(False)
+        self._set_enabled(False)
         
         # Look up the period, for fast duty cycle updates
         self._period = self._get_period()
 
-        #self.duty_cycle = 0
+        self.duty_cycle = 0
 
         # set frequency
         self.frequency = freq

--- a/src/adafruit_blinka/microcontroller/generic_linux/sysfs_pwmout.py
+++ b/src/adafruit_blinka/microcontroller/generic_linux/sysfs_pwmout.py
@@ -90,12 +90,12 @@ class PWMOut(object):
         except IOError as e:
             raise PWMError(e.errno, "Exporting PWM pin: " + e.strerror)
 
-        self._set_enabled(False)
+        #self._set_enabled(False)
         
         # Look up the period, for fast duty cycle updates
         self._period = self._get_period()
 
-        self.duty_cycle = 0
+        #self.duty_cycle = 0
 
         # set frequency
         self.frequency = freq

--- a/src/adafruit_blinka/microcontroller/sama5/pin.py
+++ b/src/adafruit_blinka/microcontroller/sama5/pin.py
@@ -1,11 +1,17 @@
 from adafruit_blinka.microcontroller.generic_linux.libgpiod_pin import Pin
 
 PD23 = Pin(119)
+AD4 = PD23
 PD21 = Pin(117)
+AD2 = PD21
 PD20 = Pin(116)
+AD1 = PD20
 PD24 = Pin(120)
+AD5 = PD24
 PD22 = Pin(118)
+AD3 = PD22
 PD19 = Pin(115)
+AD0 = PD19
 PA14 = Pin(14)
 SPI0_SCLK = PA14
 PA15 = Pin(15)
@@ -20,9 +26,13 @@ UART1_TX = PD3
 PD13 = Pin(109)
 PD31 = Pin(127)
 PB0 = Pin(32)
+PWM1 = PB0
 PB7 = Pin(38)
+PWM3 = PB7
 PB1 = Pin(33)
+PWML1 = PB1
 PB5 = Pin(37)
+PWM2 = PB5
 PB3 = Pin(35)
 PC0 = Pin(64)
 TWI0_SCL = PC0
@@ -34,3 +44,5 @@ i2cPorts = ( (0, TWI0_SCL, TWI0_SDA), )
 spiPorts = ( (0, SPI0_SCLK, SPI0_MOSI, SPI0_MISO), )
 # ordered as uartId, txId, rxId
 uartPorts = ( (1, UART1_TX, UART1_RX), )
+# SysFS pwm outputs, pwm channel and pin in first tuple
+pwmOuts = ( ((0, 1), PWM1), ((0, 2), PWM2), ((0, 3), PWM3), )

--- a/src/pulseio.py
+++ b/src/pulseio.py
@@ -4,3 +4,5 @@ if detector.board.any_raspberry_pi:
     from adafruit_blinka.microcontroller.bcm283x.pulseio.PulseIn import PulseIn
 if detector.board.any_coral_board:
     from adafruit_blinka.microcontroller.generic_linux.sysfs_pwmout import PWMOut
+if detector.board.any_giant_board:
+    from adafruit_blinka.microcontroller.generic_linux.sysfs_pwmout import PWMOut


### PR DESCRIPTION
This pull request:
- Add alternate pin names
- Add sysfs pwm pins
- Update pulseio.py to include Giant Board
- Fix import errors for sysfs pwm