### PR TITLE
Fix for sysfs PWM `Invalid argument` write error when trying to setup the device.

### DIFF
--- a/src/adafruit_blinka/microcontroller/generic_linux/sysfs_pwmout.py
+++ b/src/adafruit_blinka/microcontroller/generic_linux/sysfs_pwmout.py
@@ -95,7 +95,7 @@ class PWMOut(object):
         # Look up the period, for fast duty cycle updates
         self._period = self._get_period()
 
-        self.duty_cycle = 0
+        #self.duty_cycle = 0  # This line causes a write error when trying to enable
 
         # set frequency
         self.frequency = freq

--- a/src/adafruit_blinka/microcontroller/generic_linux/sysfs_pwmout.py
+++ b/src/adafruit_blinka/microcontroller/generic_linux/sysfs_pwmout.py
@@ -90,8 +90,8 @@ class PWMOut(object):
         except IOError as e:
             raise PWMError(e.errno, "Exporting PWM pin: " + e.strerror)
 
-        self._set_enabled(False)
-        
+        #self._set_enabled(False) # This line causes a write error when trying to enable
+                
         # Look up the period, for fast duty cycle updates
         self._period = self._get_period()
 


### PR DESCRIPTION
This pull request:
- Fix sysfsPWM write error on export
 
After some more testing, I've found this line to be my culprit for not allowing the PWM to be used. After commenting the line, everything appears to work as it should.

This line `self._set_enabled(False)` and this line `self.duty_cycle = 0` throws an `Invalid argument` when trying to write to the device:


```
Traceback (most recent call last):
  File "pwmtest.py", line 5, in <module>
    led = pulseio.PWMOut(board.PWM1, frequency=5000, duty_cycle=0)
  File "/usr/local/lib/python3.5/dist-packages/Adafruit_Blinka-1.3.3.dev2+gf599d17.d20190519-py3.5.egg/adafruit_blinka/microcontroller/generic_linux/sysfs_pwmout.py", line 55, in __init__
    self._open(pin, duty_cycle, frequency, variable_frequency)
  File "/usr/local/lib/python3.5/dist-packages/Adafruit_Blinka-1.3.3.dev2+gf599d17.d20190519-py3.5.egg/adafruit_blinka/microcontroller/generic_linux/sysfs_pwmout.py", line 101, in _open
    self.frequency = freq
  File "/usr/local/lib/python3.5/dist-packages/Adafruit_Blinka-1.3.3.dev2+gf599d17.d20190519-py3.5.egg/adafruit_blinka/microcontroller/generic_linux/sysfs_pwmout.py", line 230, in _set_frequency
    self._set_period(1.0 / frequency)
  File "/usr/local/lib/python3.5/dist-packages/Adafruit_Blinka-1.3.3.dev2+gf599d17.d20190519-py3.5.egg/adafruit_blinka/microcontroller/generic_linux/sysfs_pwmout.py", line 165, in _set_period
    self._write_pin_attr(self._pin_period_path, "{}".format(period_ns))
  File "/usr/local/lib/python3.5/dist-packages/Adafruit_Blinka-1.3.3.dev2+gf599d17.d20190519-py3.5.egg/adafruit_blinka/microcontroller/generic_linux/sysfs_pwmout.py", line 130, in _write_pin_attr
    f_attr.write(value + "\n")
OSError: [Errno 22] Invalid argument
```

![giantboardPWM](https://user-images.githubusercontent.com/16845266/57983513-836f9b00-7a07-11e9-8516-60ddc6c0d5d7.gif)