### PR TITLE
Add SAMA5 to set_no_cs to allow SPI device to setup.

### DIFF
--- a/src/adafruit_blinka/microcontroller/generic_linux/spi.py
+++ b/src/adafruit_blinka/microcontroller/generic_linux/spi.py
@@ -35,7 +35,7 @@ class SPI:
     def set_no_cs(self):
         # Linux SPI driver for AM33XX chip in BeagleBone and PocketBeagle
         # does not support setting SPI_NO_CS mode bit (issue #104)
-        if not self.chip.AM33XX and not self.chip.IMX8MX:
+        if not self.chip.AM33XX and not self.chip.IMX8MX and not self.chip.SAMA5:
             try:
                 self._spi.no_cs = True  # this doesn't work but try anyways
             except AttributeError:


### PR DESCRIPTION
This pull request:
- Adds SAMA5 to set_no_cs method