### PR TITLE
Add property to period method

### DIFF
--- a/src/adafruit_blinka/microcontroller/generic_linux/sysfs_pwmout.py
+++ b/src/adafruit_blinka/microcontroller/generic_linux/sysfs_pwmout.py
@@ -167,6 +167,8 @@ class PWMOut(object):
         # Update our cached period
         self._period = float(period)
 
+    period = property(_get_period, _set_period)
+
     """Get or set the PWM's output period in seconds.
 
     Raises:


### PR DESCRIPTION
Addressing https://github.com/adafruit/Adafruit_Blinka/issues/125

Tested on Google Coral
```
>>> pwm.period = 1
>>> pwm.period
1.0
```