### PR TITLE
Removed Odroid C2 from pulseio

### DIFF
--- a/src/pulseio.py
+++ b/src/pulseio.py
@@ -6,5 +6,3 @@ if detector.board.any_coral_board:
     from adafruit_blinka.microcontroller.generic_linux.sysfs_pwmout import PWMOut
 if detector.board.any_giant_board:
     from adafruit_blinka.microcontroller.generic_linux.sysfs_pwmout import PWMOut
-if detector.board.any_odroid_40_pin:
-    from adafruit_blinka.microcontroller.generic_linux.sysfs_pwmout import PWMOut


### PR DESCRIPTION
Since there's nothing in `/sys/class/pwm` and no overlays in the latest mainline kernel release of armbian, I'm going to remove this for now.