### PR TITLE
Allows Raspberry Pi boards on arm64 to work w/ BLINKA_FORCEBOARD

### DIFF
--- a/src/busio.py
+++ b/src/busio.py
@@ -90,7 +90,7 @@ class SPI(Lockable):
                 format((clock, MOSI, MISO), spiPorts))
 
     def configure(self, baudrate=100000, polarity=0, phase=0, bits=8):
-        if detector.board.any_raspberry_pi:
+        if detector.board.any_raspberry_pi or detector.board.any_raspberry_pi_40_pin:
             from adafruit_blinka.microcontroller.bcm283x.pin import Pin
             from adafruit_blinka.microcontroller.generic_linux.spi import SPI as _SPI
         elif detector.board.any_beaglebone:


### PR DESCRIPTION
Resolves https://github.com/adafruit/Adafruit_Blinka/issues/130 for RPI boards running ubuntu/arm64 if using, for instance BLINKA_FORCEBOARD=RASPBERRY_PI_3B_PLUS and BLINKA_FORCECHIP=BCM2XXX to bypass board detection failure in Adafruit_Python_PlatformDetect.