### PR TITLE
Update requirements for SpiDev >= 3.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ Adafruit-PlatformDetect
 Adafruit-PureIO
 RPi.GPIO; platform_machine=='armv7l' or platform_machine=='armv6l'
 rpi_ws281x>=4.0.0; platform_machine=='armv7l' or platform_machine=='armv6l'
-spidev>=3.4.0; sys_platform == 'linux'
+spidev>=3.4; sys_platform == 'linux'
 sysv_ipc

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ Adafruit-PlatformDetect
 Adafruit-PureIO
 RPi.GPIO; platform_machine=='armv7l' or platform_machine=='armv6l'
 rpi_ws281x>=4.0.0; platform_machine=='armv7l' or platform_machine=='armv6l'
-spidev; sys_platform == 'linux'
+spidev>=3.4.0; sys_platform == 'linux'
 sysv_ipc

--- a/src/adafruit_blinka/microcontroller/generic_linux/spi.py
+++ b/src/adafruit_blinka/microcontroller/generic_linux/spi.py
@@ -53,11 +53,14 @@ class SPI:
             self._spi.max_speed_hz = self.baudrate
             self._spi.mode = self.mode
             self._spi.bits_per_word = self.bits
-            self._spi.writebytes2(buf[start:end])
-            self._spi.close()
         except FileNotFoundError as not_found:
             print("Could not open SPI device - check if SPI is enabled in kernel!")
             raise
+        try:
+            self._spi.writebytes2(buf[start:end])
+        except AttributeError as error:
+            self._spi.writebytes([x for x in buf[start:end]])
+        self._spi.close()
 
     def readinto(self, buf, start=0, end=None, write_value=0):
         if not buf:

--- a/src/adafruit_blinka/microcontroller/generic_linux/spi.py
+++ b/src/adafruit_blinka/microcontroller/generic_linux/spi.py
@@ -53,14 +53,11 @@ class SPI:
             self._spi.max_speed_hz = self.baudrate
             self._spi.mode = self.mode
             self._spi.bits_per_word = self.bits
+            self._spi.writebytes2(buf[start:end])
+            self._spi.close()
         except FileNotFoundError as not_found:
             print("Could not open SPI device - check if SPI is enabled in kernel!")
             raise
-        try:
-            self._spi.writebytes2(buf[start:end])
-        except AttributeError as error:
-            self._spi.writebytes([x for x in buf[start:end]])
-        self._spi.close()
 
     def readinto(self, buf, start=0, end=None, write_value=0):
         if not buf:


### PR DESCRIPTION
This fixes #144.

I'm not sure if this is the best approach or if we should just tell the user to update SPIDEV to latest version in the error.