### PR TITLE
Jetson SPI support and Jetson.GPIO requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 Adafruit-PlatformDetect
 Adafruit-PureIO
+Jetson.GPIO; platform_machine=='aarch64'
 RPi.GPIO; platform_machine=='armv7l' or platform_machine=='armv6l'
 rpi_ws281x>=4.0.0; platform_machine=='armv7l' or platform_machine=='armv6l'
 spidev; sys_platform == 'linux'

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
     install_requires=[
         "Adafruit-PlatformDetect",
         "Adafruit-PureIO",
+        "Jetson.GPIO; platform_machine=='aarch64'",
         "RPi.GPIO; platform_machine=='armv7l' or platform_machine=='armv6l'",
         "rpi_ws281x>=4.0.0; platform_machine=='armv7l' or platform_machine=='armv6l'",
         "spidev; sys_platform=='linux'",

--- a/src/adafruit_blinka/board/jetson_nano.py
+++ b/src/adafruit_blinka/board/jetson_nano.py
@@ -29,3 +29,17 @@ D24 = pin.B07
 D25 = pin.B05
 D26 = pin.B04
 D27 = pin.B06
+
+CE1 = D7
+CE0 = D8
+MISO = D9
+MOSI = D10
+SCLK = D11
+SCK = D11
+
+CE1_1 = D23
+CE0_1 = D24
+MISO_1 = D25
+MOSI_1 = D26
+SCLK_1 = D27
+SCK_1 = D27

--- a/src/adafruit_blinka/board/jetson_tx1.py
+++ b/src/adafruit_blinka/board/jetson_tx1.py
@@ -29,3 +29,10 @@ D24 = pin.X00
 D25 = pin.P16
 D26 = pin.X03
 D27 = pin.E06
+
+CE1 = D7
+CE0 = D8
+MISO = D9
+MOSI = D10
+SCLK = D11
+SCK = D11

--- a/src/adafruit_blinka/board/jetson_tx2.py
+++ b/src/adafruit_blinka/board/jetson_tx2.py
@@ -29,3 +29,10 @@ D24 = pin.Y01
 D25 = pin.P16
 D26 = pin.I04
 D27 = pin.J05
+
+CE1 = D7
+CE0 = D8
+MISO = D9
+MOSI = D10
+SCLK = D11
+SCK = D11

--- a/src/adafruit_blinka/board/jetson_tx2.py
+++ b/src/adafruit_blinka/board/jetson_tx2.py
@@ -10,6 +10,7 @@ SCL_1 = pin.SCL_1
 D4 = pin.J04
 D5 = pin.J06
 D6 = pin.AA02
+D7 = pin.N03
 D8 = pin.N06
 D9 = pin.N04
 D10 = pin.N05

--- a/src/adafruit_blinka/board/jetson_xavier.py
+++ b/src/adafruit_blinka/board/jetson_xavier.py
@@ -29,3 +29,10 @@ D24 = pin.H00
 D25 = pin.Q01
 D26 = pin.AA01
 D27 = pin.R00
+
+CE1 = D7
+CE0 = D8
+MISO = D9
+MOSI = D10
+SCLK = D11
+SCK = D11

--- a/src/adafruit_blinka/microcontroller/generic_linux/spi.py
+++ b/src/adafruit_blinka/microcontroller/generic_linux/spi.py
@@ -36,7 +36,8 @@ class SPI:
         # Linux SPI driver for AM33XX chip in BeagleBone and PocketBeagle
         # does not support setting SPI_NO_CS mode bit (issue #104)
         if not self.chip.AM33XX and not self.chip.IMX8MX and not self.chip.SAMA5 \
-         and not self.chip.APQ8016:
+         and not self.chip.APQ8016 and not self.chip.T210 and not self.chip.T186 \
+         and not self.chip.T194:
             try:
                 self._spi.no_cs = True  # this doesn't work but try anyways
             except AttributeError:

--- a/src/adafruit_blinka/microcontroller/tegra/t186/pin.py
+++ b/src/adafruit_blinka/microcontroller/tegra/t186/pin.py
@@ -1,7 +1,5 @@
 import sys
 import atexit
-sys.path.append("/opt/nvidia/jetson-gpio/lib/python")
-sys.path.append("/opt/nvidia/jetson-gpio/lib/python/Jetson/GPIO")
 import Jetson.GPIO as GPIO
 GPIO.setmode(GPIO.TEGRA_SOC)
 GPIO.setwarnings(False)   # shh!

--- a/src/adafruit_blinka/microcontroller/tegra/t186/pin.py
+++ b/src/adafruit_blinka/microcontroller/tegra/t186/pin.py
@@ -98,3 +98,6 @@ J05 = Pin('GPIO_AUD0')
 i2cPorts = (
     (1, SCL, SDA), (0, SCL_1, SDA_1),
 )
+
+# ordered as spiId, sckId, mosiId, misoId
+spiPorts = ((3, N03, N05, N04), )

--- a/src/adafruit_blinka/microcontroller/tegra/t194/pin.py
+++ b/src/adafruit_blinka/microcontroller/tegra/t194/pin.py
@@ -1,7 +1,5 @@
 import sys
 import atexit
-sys.path.append("/opt/nvidia/jetson-gpio/lib/python")
-sys.path.append("/opt/nvidia/jetson-gpio/lib/python/Jetson/GPIO")
 import Jetson.GPIO as GPIO
 GPIO.setmode(GPIO.TEGRA_SOC)
 GPIO.setwarnings(False)   # shh!

--- a/src/adafruit_blinka/microcontroller/tegra/t194/pin.py
+++ b/src/adafruit_blinka/microcontroller/tegra/t194/pin.py
@@ -99,3 +99,6 @@ R00 = Pin('SOC_GPIO44')
 i2cPorts = (
     (8, SCL, SDA), (1, SCL_1, SDA_1),
 )
+
+# ordered as spiId, sckId, mosiId, misoId
+spiPorts = ((0, Z03, Z05, Z04), )

--- a/src/adafruit_blinka/microcontroller/tegra/t210/pin.py
+++ b/src/adafruit_blinka/microcontroller/tegra/t210/pin.py
@@ -119,3 +119,6 @@ E06 = Pin('GPIO_PE6')
 i2cPorts = (
     (0, SCL, SDA), (1, SCL_1, SDA_1),
 )
+
+# ordered as spiId, sckId, mosiId, misoId
+spiPorts = ((0, C02, C00, C01), (1, B06, B04, B05))

--- a/src/adafruit_blinka/microcontroller/tegra/t210/pin.py
+++ b/src/adafruit_blinka/microcontroller/tegra/t210/pin.py
@@ -1,7 +1,5 @@
 import sys
 import atexit
-sys.path.append("/opt/nvidia/jetson-gpio/lib/python")
-sys.path.append("/opt/nvidia/jetson-gpio/lib/python/Jetson/GPIO")
 import Jetson.GPIO as GPIO
 GPIO.setmode(GPIO.TEGRA_SOC)
 GPIO.setwarnings(False)   # shh!

--- a/src/busio.py
+++ b/src/busio.py
@@ -111,6 +111,18 @@ class SPI(Lockable):
         elif board_id == ap_board.DRAGONBOARD_410C:
             from adafruit_blinka.microcontroller.snapdragon.apq8016.pin import Pin
             from adafruit_blinka.microcontroller.generic_linux.spi import SPI as _SPI
+        elif board_id == ap_board.JETSON_NANO:
+            from adafruit_blinka.microcontroller.generic_linux.spi import SPI as _SPI
+            from adafruit_blinka.microcontroller.tegra.t210.pin import Pin
+        elif board_id == ap_board.JETSON_TX1:
+            from adafruit_blinka.microcontroller.generic_linux.spi import SPI as _SPI
+            from adafruit_blinka.microcontroller.tegra.t210.pin import Pin
+        elif board_id == ap_board.JETSON_TX2:
+            from adafruit_blinka.microcontroller.generic_linux.spi import SPI as _SPI
+            from adafruit_blinka.microcontroller.tegra.t186.pin import Pin
+        elif board_id == ap_board.JETSON_XAVIER:
+            from adafruit_blinka.microcontroller.generic_linux.spi import SPI as _SPI
+            from adafruit_blinka.microcontroller.tegra.t194.pin import Pin
         else:
             from machine import SPI as _SPI
             from machine import Pin


### PR DESCRIPTION
Support SPI controllers on Jetson.
Depend on Jetson.GPIO and stop hard-coding its expected installation path.
Add missing D7 pin definition on Jetson TX2.