### PR TITLE
setup.py: Runtime dependency determination

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,18 @@ here = os.path.abspath(os.path.dirname(__file__))
 with io.open(os.path.join(here, 'README.rst'), encoding='utf-8') as f:
     long_description = '\n' + f.read()
 
+board_reqs = []
+if os.path.exists('/proc/device-tree/compatible'):
+    with open('/proc/device-tree/compatible', 'rb') as f:
+        compat = f.read()
+    if b'nvidia,tegra' in compat:
+        board_reqs = ['Jetson.GPIO']
+    if b'brcm,bcm2835' in compat or \
+       b'brcm,bcm2836' in compat or \
+       b'brcm,bcm2837' in compat or \
+       b'brcm,bcm2838' in compat:
+        board_reqs = ['RPi.GPIO', 'rpi_ws281x>=4.0.0']
+
 setup(
     name='Adafruit-Blinka',
     use_scm_version=True,
@@ -37,12 +49,9 @@ setup(
     install_requires=[
         "Adafruit-PlatformDetect",
         "Adafruit-PureIO",
-        "Jetson.GPIO; platform_machine=='aarch64'",
-        "RPi.GPIO; platform_machine=='armv7l' or platform_machine=='armv6l'",
-        "rpi_ws281x>=4.0.0; platform_machine=='armv7l' or platform_machine=='armv6l'",
         "spidev; sys_platform=='linux'",
         "sysv_ipc; platform_system != 'Windows'"
-    ],
+    ] + board_reqs,
     license='MIT',
     classifiers=[
         # Trove classifiers


### PR DESCRIPTION
setup.py currently assumes that all ARMv6/7 platforms are an RPi, and all
AArch64 systems are a Jetson. This is untrue, since:

a) All recent ARM Linux systems are one of those types, and Blinka
supports plenty of Linux systems besides the Pi and Jetson.

b) Recent Pis are quite capable of running an AArch64 user-space, and
Jetson could run an ARMv7 user-spcae.

Solve this by enhancing setup.py to detect which specific system it's
running on, using the device tree compatible value. (Other mechanisms
could be used for other types of system in the future if required.) The
active dependency list is calculated based on this information.

There have been some bugs reported[1] that could only have occurred if
the previous platform limitations in setup.py's install_requires were not
correctly implemented, or people were running non-default user-space.
This change will ensure only the expected libraries are installed in
those cases.

[1]
https://github.com/NVIDIA/jetson-gpio/issues/19
https://github.com/adafruit/Adafruit_Blinka/issues/149

I have tested this on one Jetson system. I have not tested it on a Pi,
nor other systems supported by Blinka. However, I have confirmed the Pi
compatible values match those used by:

- The upstream Linux kernel.

- The latest Pi Foundation kernel.

- Pi Foundation kernel 4.8, from around Jan 2017.
  4.7 used different compatible values.