### PR TITLE
Adds Raspberry Pi 1 Model A

### DIFF
--- a/src/board.py
+++ b/src/board.py
@@ -49,7 +49,7 @@ elif detector.board.any_raspberry_pi_40_pin:
 elif detector.board.any_raspberry_pi_cm:
     from adafruit_blinka.board.raspi_cm import *
 
-elif detector.board.RASPBERRY_PI_B_REV1:
+elif detector.board.RASPBERRY_PI_A or detector.board.RASPBERRY_PI_B_REV1:
     from adafruit_blinka.board.raspi_1b_rev1 import *
 
 elif detector.board.RASPBERRY_PI_B_REV2:


### PR DESCRIPTION
According to the schematics for the original Pis posted at https://www.raspberrypi.org/app/uploads/2012/04/Raspberry-Pi-Schematics-R1.0.pdf, the connections to the chips for Pi 1 Model A and Pi 1 Model B Rev 1 should be exactly the same. So if Pi 1 Model A is detected, I'm using the Pi 1 Model B Rev 1 pinouts in this PR. I don't have the Pi 1 Model A on hand, so I'll have a user test it.