### PR TITLE
Add SPI frequency property

### DIFF
--- a/src/adafruit_blinka/microcontroller/ft232h/spi.py
+++ b/src/adafruit_blinka/microcontroller/ft232h/spi.py
@@ -3,55 +3,47 @@ from adafruit_blinka.microcontroller.ft232h.pin import Pin
 class SPI:
     MSB = 0
 
-    baudrate = 100000
-    mode = 0
-    bits = 8
-
     def __init__(self):
-        # change GPIO controller to SPI
         from pyftdi.spi import SpiController
         self._spi = SpiController(cs_count=1)
         self._spi.configure('ftdi:///1')
+        self._port = self._spi.get_port(0)
+        self._port.set_frequency(100000)
+        self._port._cpol = 0
+        self._port._cpha = 0
+        # Change GPIO controller to SPI
         Pin.ft232h_gpio = self._spi.get_gpio()
 
     def init(self, baudrate=100000, polarity=0, phase=0, bits=8,
                   firstbit=MSB, sck=None, mosi=None, miso=None):
-        self.cs = 0
-        self.freq = baudrate
-        if polarity == 0 and phase == 0:
-            self.mode = 0
-        elif polarity == 0 and phase == 1:
-            self.mode = 1
-        elif polarity == 1 and phase == 0:
-            raise ValueError("SPI mode 2 is not supported.")
-        elif polarity == 1 and phase == 1:
-            self.mode = 3
-        else:
-            raise ValueError("Unknown SPI mode.")
+        self._port.set_frequency(baudrate)
+        self._port._cpol = polarity
+        self._port._cpha = phase
+
+    @property
+    def frequency(self):
+        return self._port.frequency
 
     def write(self, buf, start=0, end=None):
         end = end if end else len(buf)
-        port = self._spi.get_port(self.cs, self.freq, self.mode)
         chunks, rest = divmod(end - start, self._spi.PAYLOAD_MAX_LENGTH)
         for i in range(chunks):
             chunk_start = start + i * self._spi.PAYLOAD_MAX_LENGTH
             chunk_end = chunk_start + self._spi.PAYLOAD_MAX_LENGTH
-            port.write(buf[chunk_start:chunk_end])
+            self._port.write(buf[chunk_start:chunk_end])
         if rest:
-            port.write(buf[-1*rest:])
+            self._port.write(buf[-1*rest:])
 
     def readinto(self, buf, start=0, end=None, write_value=0):
         end = end if end else len(buf)
-        port = self._spi.get_port(self.cs, self.freq, self.mode)
-        result = port.read(end-start)
+        result = self._port.read(end-start)
         for i, b in enumerate(result):
             buf[start+i] = b
 
     def write_readinto(self, buffer_out, buffer_in,  out_start=0, out_end=None, in_start=0, in_end=None):
         out_end = out_end if out_end else len(buffer_out)
         in_end = in_end if in_end else len(buffer_in)
-        port = self._spi.get_port(self.cs, self.freq, self.mode)
-        result = port.exchange(buffer_out[out_start:out_end],
-                               in_end-in_start, duplex=True)
+        result = self._port.exchange(buffer_out[out_start:out_end],
+                                     in_end-in_start, duplex=True)
         for i, b in enumerate(result):
             buffer_in[in_start+i] = b

--- a/src/adafruit_blinka/microcontroller/generic_linux/spi.py
+++ b/src/adafruit_blinka/microcontroller/generic_linux/spi.py
@@ -43,6 +43,10 @@ class SPI:
             except AttributeError:
                 pass
 
+    @property
+    def frequency(self):
+        return self.baudrate
+
     def write(self, buf, start=0, end=None):
         if not buf:
             return

--- a/src/busio.py
+++ b/src/busio.py
@@ -159,6 +159,13 @@ class SPI(Lockable):
         self._spi = None
         self._pinIds = None
 
+    @property
+    def frequency(self):
+        try:
+            return self._spi.frequency
+        except AttributeError:
+            raise NotImplementedError("Frequency attribute not implemented for this platform")
+
     def write(self, buf, start=0, end=None):
         return self._spi.write(buf, start, end)
 


### PR DESCRIPTION
For #161 

Note that there is also some refactoring of the FT232H SPI internals. This was motivated by discovering that subsequent changes to frequency were not taking effect. Now a port instance is kept around and changed as needed. These changes were tested to still work with a BME280 and also SPI driven NeoPixels.

**Querying SPI frequency on a PC with FT232H:**
```
:~$ python3
Python 3.6.8 (default, Aug 20 2019, 17:12:48) 
[GCC 8.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import board
>>> spi = board.SPI()
>>> spi.frequency
100000 
>>> 
```

**Querying SPI frequency on a RPI:**
```
pi@raspberrypi:~ $ python3
Python 3.7.3 (default, Apr  3 2019, 05:39:12) 
[GCC 8.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import board
>>> spi = board.SPI()
>>> spi.frequency
100000
>>> 
```
