### PR TITLE
Fix missing attribute exception catch for 'SPI.chip' on RPi

### DIFF
--- a/src/adafruit_blinka/microcontroller/generic_linux/spi.py
+++ b/src/adafruit_blinka/microcontroller/generic_linux/spi.py
@@ -35,13 +35,13 @@ class SPI:
     def set_no_cs(self):
         # Linux SPI driver for AM33XX chip in BeagleBone and PocketBeagle
         # does not support setting SPI_NO_CS mode bit (issue #104)
-        if not self.chip.AM33XX and not self.chip.IMX8MX and not self.chip.SAMA5 \
-         and not self.chip.APQ8016 and not self.chip.T210 and not self.chip.T186 \
-         and not self.chip.T194 and not self.chip.SUN8I:
-            try:
+        try:
+            if not self.chip.AM33XX and not self.chip.IMX8MX and not self.chip.SAMA5 \
+             and not self.chip.APQ8016 and not self.chip.T210 and not self.chip.T186 \
+             and not self.chip.T194 and not self.chip.SUN8I:
                 self._spi.no_cs = True  # this doesn't work but try anyways
-            except AttributeError:
-                pass
+        except AttributeError:
+            pass
 
     @property
     def frequency(self):


### PR DESCRIPTION
Previous version did not catch `AttributeError: 'SPI' object has no attribute 'chip'`, which occurs, e.g., on RPi3 running Debian Buster.