### PR TITLE
Changed error to more appropriate type

### DIFF
--- a/src/busio.py
+++ b/src/busio.py
@@ -31,7 +31,7 @@ class I2C(Lockable):
                 self._i2c = _I2C(portId, mode=_I2C.MASTER, baudrate=frequency)
                 break
         else:
-            raise NotImplementedError(
+            raise ValueError(
                 "No Hardware I2C on (scl,sda)={}\nValid I2C ports: {}".format((scl, sda), i2cPorts)
             )
 
@@ -95,7 +95,7 @@ class SPI(Lockable):
                 self._pins = (portSck, portMosi, portMiso)
                 break
         else:
-            raise NotImplementedError(
+            raise ValueError(
                 "No Hardware SPI on (SCLK, MOSI, MISO)={}\nValid SPI ports:{}".
                 format((clock, MOSI, MISO), spiPorts))
 
@@ -230,7 +230,7 @@ class UART(Lockable):
                 )
                 break
         else:
-            raise NotImplementedError(
+            raise ValueError(
                 "No Hardware UART on (tx,rx)={}\nValid UART ports: {}".format((tx, rx), uartPorts)
             )
 


### PR DESCRIPTION
ValueError makes more sense since the feature is actually implemented.

This fixes https://github.com/adafruit/Adafruit_CircuitPython_WS2801/issues/6 in that it doesn't just quit, but I haven't tested with lights.