### PR TITLE
Add a lock for thread safety when the I2C class is used in a with statement

### DIFF
--- a/src/busio.py
+++ b/src/busio.py
@@ -7,6 +7,8 @@ See `CircuitPython:busio` in CircuitPython for more details.
 * Author(s): cefn
 """
 
+import threading
+
 from adafruit_blinka import Enum, Lockable, agnostic
 from adafruit_blinka.agnostic import board_id, detector
 import adafruit_platformdetect.board as ap_board
@@ -35,6 +37,8 @@ class I2C(Lockable):
                 "No Hardware I2C on (scl,sda)={}\nValid I2C ports: {}".format((scl, sda), i2cPorts)
             )
 
+        self._lock = threading.RLock()
+
     def deinit(self):
         try:
             del self._i2c
@@ -42,9 +46,11 @@ class I2C(Lockable):
             pass
 
     def __enter__(self):
+        self._lock.acquire()
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
+        self._lock.release()
         self.deinit()
 
     def scan(self):


### PR DESCRIPTION
This is a pull request for issue #40 at https://github.com/adafruit/Adafruit_CircuitPython_ADS1x15/issues/40#issuecomment-548527569, which it turns out is best to fix in this project.

I have added a thread.RLock so that only one thread can access the ADS as once, preventing deadlocks. I haven't been able to make the original code crash very easily, but I can confirm that it does, after a similar fix downstream in my project resolved the issue. As it is a race condition, I am unsure how to provide a test program to demonstrate the fix, but existing code seems to work fine with this modification.