### PR TITLE
Update jetson_nano.py

### DIFF
--- a/src/adafruit_blinka/board/jetson_nano.py
+++ b/src/adafruit_blinka/board/jetson_nano.py
@@ -2,10 +2,17 @@
 
 from adafruit_blinka.microcontroller.tegra.t210 import pin
 
-SDA = pin.SDA_1
-SCL = pin.SCL_1
-SDA_1 = pin.SDA
-SCL_1 = pin.SCL
+# before #
+#SDA = pin.SDA_1
+#SCL = pin.SCL_1
+#SDA_1 = pin.SDA
+#SCL_1 = pin.SCL
+
+# after #
+SDA = pin.SDA
+SCL = pin.SCL
+SDA_1 = pin.SDA_1
+SCL_1 = pin.SCL_1
 
 D4 = pin.BB00
 D5 = pin.S05


### PR DESCRIPTION
started from Pull
https://github.com/adafruit/Adafruit_Blinka/pull/176

when i tried busio.py with I2C bus 0
(https://github.com/adafruit/Adafruit_Blinka/blob/master/src/busio.py)
30, 31 line make 'portId' to '1'

bacause 28 line 'microcontroller.pin import i2cPorts' import below
'https://github.com/adafruit/Adafruit_Blinka/blob/master/src/adafruit_blinka/microcontroller/tegra/t210/pin.py'
in there, 117, 119 line 
i2cPorts = (
    (0, SCL, SDA), (1, SCL_1, SDA_1),
)

so when i try use below code, can't use I2C 0
https://github.com/adafruit/Adafruit_CircuitPython_LSM303DLH_Mag/blob/master/examples/lsm303dlh_mag_simpletest.py