### PR TITLE
Revert "Update pin.py"

### DIFF
--- a/src/adafruit_blinka/microcontroller/tegra/t210/pin.py
+++ b/src/adafruit_blinka/microcontroller/tegra/t210/pin.py
@@ -66,17 +66,10 @@ class Pin:
         GPIO.cleanup()
 
 # Cannot be used as GPIO
-# before #
-#SDA = Pin('GEN1_I2C_SDA')
-#SCL = Pin('GEN1_I2C_SCL')
-#SDA_1 = Pin('GEN2_I2C_SDA')
-#SCL_1 = Pin('GEN2_I2C_SCL')
-
-# after #
-SDA = Pin('GEN2_I2C_SDA')
-SCL = Pin('GEN2_I2C_SCL')
-SDA_1 = Pin('GEN1_I2C_SDA')
-SCL_1 = Pin('GEN1_I2C_SCL')
+SDA = Pin('GEN1_I2C_SDA')
+SCL = Pin('GEN1_I2C_SCL')
+SDA_1 = Pin('GEN2_I2C_SDA')
+SCL_1 = Pin('GEN2_I2C_SCL')
 
 # These pins are native to TX1
 BB03 = Pin('GPIO_X1_AUD')


### PR DESCRIPTION
Reverts adafruit/Adafruit_Blinka#176

I need to undo this. Changes #175 and #176 break the Jetson TX1.