### PR TITLE
Added spidev >= 3.4 in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
     install_requires=[
         "Adafruit-PlatformDetect",
         "Adafruit-PureIO",
-        "spidev; sys_platform=='linux'",
+        "spidev>=3.4; sys_platform=='linux'",
         "sysv_ipc; platform_system != 'Windows'"
     ] + board_reqs,
     license='MIT',


### PR DESCRIPTION
Spidev was specified to be >= 3.4 in requirements,txt, but not setup.py which resulted in people having SPIDEV 3.3 installed. This should fix it.