### PR TITLE
Add stubs for micropython.natve, viper, and asm_thumb

### DIFF
--- a/src/micropython.py
+++ b/src/micropython.py
@@ -1,2 +1,14 @@
 def const(x):
     return x
+
+
+def native(f):
+    return f
+
+
+def viper(f):
+    raise SyntaxError("invalid micropython decorator")
+
+
+def asm_thumb(f):
+    raise SyntaxError("invalid micropython decorator")


### PR DESCRIPTION
Thanks to https://github.com/adafruit/circuitpython/pull/2271 and https://github.com/adafruit/circuitpython/pull/2282, CircuitPython 5 will support the `micropython.native` decorator (and friends, if enabled). This adds similar behavior to the Blinka library. It matches the behavior of a board that doesn't have these optimizations enabled:

* `native` will do nothing.
* `viper` will raise a `SyntaxError`..
* `asm_thumb` will raise a `SyntaxError`.

This will ensure that drivers written for CircuitPython 5 that have optional optimizations will work as expected.