### PR TITLE
Blinka will now work with i2c-3 automatically

### DIFF
--- a/src/adafruit_blinka/board/raspi_40pin.py
+++ b/src/adafruit_blinka/board/raspi_40pin.py
@@ -2,6 +2,9 @@
 
 from adafruit_blinka.microcontroller.bcm283x import pin
 
+D0 = pin.D0
+D1 = pin.D1
+
 D2 = pin.D2
 SDA = pin.SDA
 D3 = pin.D3

--- a/src/adafruit_blinka/microcontroller/bcm283x/pin.py
+++ b/src/adafruit_blinka/microcontroller/bcm283x/pin.py
@@ -139,6 +139,5 @@ uartPorts = (
 )
 
 i2cPorts = (
-    (1, SCL, SDA), (0, D1, D0),   # both pi 1 and pi 2 i2c ports!
+    (3, SCL, SDA), (1, SCL, SDA), (0, D1, D0),   # both pi 1 and pi 2 i2c ports!
 )
-

--- a/src/busio.py
+++ b/src/busio.py
@@ -28,10 +28,15 @@ class I2C(Lockable):
         else:
             from machine import I2C as _I2C
         from microcontroller.pin import i2cPorts
+        busnum = None
         for portId, portScl, portSda in i2cPorts:
-            if scl == portScl and sda == portSda:
-                self._i2c = _I2C(portId, mode=_I2C.MASTER, baudrate=frequency)
-                break
+            try:
+                if scl == portScl and sda == portSda:
+                    self._i2c = _I2C(portId, mode=_I2C.MASTER, baudrate=frequency)
+                    busnum = portId
+                    break
+            except RuntimeError:
+                pass
         else:
             raise ValueError(
                 "No Hardware I2C on (scl,sda)={}\nValid I2C ports: {}".format((scl, sda), i2cPorts)

--- a/src/busio.py
+++ b/src/busio.py
@@ -28,12 +28,10 @@ class I2C(Lockable):
         else:
             from machine import I2C as _I2C
         from microcontroller.pin import i2cPorts
-        busnum = None
         for portId, portScl, portSda in i2cPorts:
             try:
                 if scl == portScl and sda == portSda:
                     self._i2c = _I2C(portId, mode=_I2C.MASTER, baudrate=frequency)
-                    busnum = portId
                     break
             except RuntimeError:
                 pass


### PR DESCRIPTION
I added i2c-3, which uses SDA and SCL as well. I have updated the I2C code to go with the first one that successfully loads rather than the first that pin-matches and have tested this on i2c-1 and i2c-3 with an Adafruit PiOLED. I also exposed Pins D0 and D1 on the board definition because it seems pointless having i2c-0 defined using D0 and D1 if it can't even be used.