### PR TITLE
Added BEAGLEBONE_BLACK_INDUSTRIAL to board.py

### DIFF
--- a/src/board.py
+++ b/src/board.py
@@ -57,6 +57,9 @@ elif detector.board.RASPBERRY_PI_B_REV2:
 
 elif board_id == ap_board.BEAGLEBONE_BLACK:
     from adafruit_blinka.board.beaglebone_black import *
+	
+elif board_id == ap_board.BEAGLEBONE_BLACK_INDUSTRIAL:
+    from adafruit_blinka.board.beaglebone_black import *
 
 elif board_id == ap_board.BEAGLEBONE_GREEN_WIRELESS:
     from adafruit_blinka.board.beaglebone_black import *


### PR DESCRIPTION
It still imports from adafruit_blinka.board.beaglebone_black because it is otherwise
compatible except for the increased temperature range.