### PR TITLE
Add RX TX aliases for raspberry pi

### DIFF
--- a/src/adafruit_blinka/board/raspi_1b_rev1.py
+++ b/src/adafruit_blinka/board/raspi_1b_rev1.py
@@ -24,6 +24,9 @@ D14 = pin.D14
 TXD = pin.D14
 D15 = pin.D15
 RXD = pin.D15
+# create alias for most of the examples
+TX = pin.D14
+RX = pin.D15
 
 D17 = pin.D17
 D18 = pin.D18

--- a/src/adafruit_blinka/board/raspi_1b_rev2.py
+++ b/src/adafruit_blinka/board/raspi_1b_rev2.py
@@ -24,6 +24,9 @@ D14 = pin.D14
 TXD = pin.D14
 D15 = pin.D15
 RXD = pin.D15
+# create alias for most of the examples
+TX = pin.D14
+RX = pin.D15
 
 D17 = pin.D17
 D18 = pin.D18

--- a/src/adafruit_blinka/board/raspi_40pin.py
+++ b/src/adafruit_blinka/board/raspi_40pin.py
@@ -33,6 +33,9 @@ D14 = pin.D14
 TXD = pin.D14
 D15 = pin.D15
 RXD = pin.D15
+# create alias for most of the examples
+TX = pin.D14
+RX = pin.D15
 
 D16 = pin.D16
 D17 = pin.D17

--- a/src/adafruit_blinka/board/raspi_cm.py
+++ b/src/adafruit_blinka/board/raspi_cm.py
@@ -30,6 +30,9 @@ D14 = pin.D14
 TXD = pin.D14
 D15 = pin.D15
 RXD = pin.D15
+# create alias for most of the examples
+TX = pin.D14
+RX = pin.D15
 
 D16 = pin.D16
 D17 = pin.D17


### PR DESCRIPTION
The example code relies on the existence of `RX` and `TX`, but the naming in the raspberry pi files is inconsistent (`RXD` and `TXD`).