### PR TITLE
Add PWMOut support for BeagleBone

### DIFF
--- a/src/adafruit_blinka/board/beaglebone_black.py
+++ b/src/adafruit_blinka/board/beaglebone_black.py
@@ -174,3 +174,8 @@ MISO_1 = pin.SPI1_D1    # P9_30
 SCLK_1 = pin.SPI1_SCLK  # P9_31
 # CircuitPython naming convention for SPI Clock
 SCK_1 = SCLK_1
+
+PWM1 = P9_14
+PWM2 = P9_14
+PWM3 = P8_19
+PWM4 = P8_13

--- a/src/adafruit_blinka/board/beaglebone_pocketbeagle.py
+++ b/src/adafruit_blinka/board/beaglebone_pocketbeagle.py
@@ -136,3 +136,8 @@ RX = RX_0
 # UART4
 TX_4 = pin.UART4_TXD    # P2_7
 RX_4 = pin.UART4_RXD    # P2_5
+
+PWM1 = P1_36
+PWM2 = P1_33
+PWM3 = P2_1
+PWM4 = P2_3

--- a/src/adafruit_blinka/microcontroller/am335x/pin.py
+++ b/src/adafruit_blinka/microcontroller/am335x/pin.py
@@ -344,9 +344,4 @@ i2cPorts = (
     (2, I2C2_SCL, I2C2_SDA),
 )
 
-PWM1 = P1_36
-PWM2 = P1_33
-PWM3 = P2_1
-PWM4 = P2_3
-
 pwmOuts = ( ((0, 0), PWM1), ((0, 1), PWM2), ((2, 0), PWM3), ((4, 1), PWM4) )


### PR DESCRIPTION
While #168 added PWMOut for PocketBeagle, the BeagleBone boards with their P8/P9 headers need to be added.

I believe the correct approach is to define the `PWM1..4` pins in the board files and keep the `pwmOuts` definition in the am335x/pins.py