### PR TITLE
Removing hidapi from requirements to fix Travis

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,4 @@ rpi_ws281x>=4.0.0; platform_machine=='armv7l' or platform_machine=='armv6l'
 spidev>=3.4; sys_platform == 'linux'
 sysv_ipc; sys_platform == 'linux'
 pyftdi>=0.30.0
-hidapi
 binho-host-adapter>=0.1.4


### PR DESCRIPTION
Since having hidapi in requirements.txt causes anything with a Blinka dependency to fail that doesn't install libusb (see #202), the easiest thing to do is leave it out of requirements.txt, but leave it in setup.py.

The method we have the user following (pip3 install adafruit-blinka) will still have it work because that uses setup.py whereas the repos use `pip3 install -r requirements.txt`.

Fixes #202.