### PR TITLE
Updated to not install spidev automatically on the mips platform

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ Adafruit-PureIO
 Jetson.GPIO; platform_machine=='aarch64'
 RPi.GPIO; platform_machine=='armv7l' or platform_machine=='armv6l'
 rpi_ws281x>=4.0.0; platform_machine=='armv7l' or platform_machine=='armv6l'
-spidev>=3.4; sys_platform == 'linux'
+spidev>=3.4; sys_platform == 'linux' and platform_machine!='mips'
 sysv_ipc; sys_platform == 'linux' and platform_machine!='mips'
 pyftdi>=0.30.0
 binho-host-adapter>=0.1.4

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
     install_requires=[
         "Adafruit-PlatformDetect",
         "Adafruit-PureIO",
-        "spidev>=3.4; sys_platform=='linux'",
+        "spidev>=3.4; sys_platform=='linux' and platform_machine!='mips'",
         "sysv_ipc; platform_system != 'Windows' and platform_machine != 'mips'",
         "pyftdi>=0.30.0"
     ] + board_reqs,


### PR DESCRIPTION
If we can get the specific for each board such as detecting the Onion running openwrt, we can add specific requirements in another PR like we did for the RPi-GPIO and Jetson-GPIO.