### PR TITLE
Simple refactor to place all AllWinner boards within the same module

### DIFF
--- a/src/adafruit_blinka/board/orangepipc.py
+++ b/src/adafruit_blinka/board/orangepipc.py
@@ -1,6 +1,6 @@
 """Pin definitions for the Orange Pi PC."""
 
-from adafruit_blinka.microcontroller.allwinner_h3 import pin
+from adafruit_blinka.microcontroller.allwinner.h3 import pin
 
 PA12 = pin.PA12
 SDA = pin.PA12

--- a/src/adafruit_blinka/board/orangepir1.py
+++ b/src/adafruit_blinka/board/orangepir1.py
@@ -1,6 +1,6 @@
 """Pin definitions for the Orange Pi R1."""
 
-from adafruit_blinka.microcontroller.allwinner_h3 import pin
+from adafruit_blinka.microcontroller.allwinner.h3 import pin
 
 PA12 = pin.PA12
 SDA = pin.PA12

--- a/src/adafruit_blinka/board/orangepizero.py
+++ b/src/adafruit_blinka/board/orangepizero.py
@@ -2,7 +2,7 @@
 
 # The Orange Pi Zero uses the AllWinner H2 SoC, but pins 
 # are the same as the AllWinner H3 SoC, so we import those
-from adafruit_blinka.microcontroller.allwinner_h3 import pin
+from adafruit_blinka.microcontroller.allwinner.h3 import pin
 
 PA12 = pin.PA12
 SDA = pin.PA12

--- a/src/adafruit_blinka/board/tritium-h3.py
+++ b/src/adafruit_blinka/board/tritium-h3.py
@@ -1,6 +1,6 @@
 """Pin definitions for the Tritium H3."""
 
-from adafruit_blinka.microcontroller.allwinner_h3 import pin
+from adafruit_blinka.microcontroller.allwinner.h3 import pin
 
 PA12 = pin.PA12
 SDA = pin.PA12

--- a/src/adafruit_blinka/microcontroller/allwinner/__init__.py
+++ b/src/adafruit_blinka/microcontroller/allwinner/__init__.py
@@ -1,0 +1,1 @@
+"""Definition of all Allwinner chips"""

--- a/src/adafruit_blinka/microcontroller/allwinner/a64/__init__.py
+++ b/src/adafruit_blinka/microcontroller/allwinner/a64/__init__.py
@@ -1,0 +1,1 @@
+"""Definition for the AllWinner A64 chip"""

--- a/src/adafruit_blinka/microcontroller/allwinner/a64/pin.py
+++ b/src/adafruit_blinka/microcontroller/allwinner/a64/pin.py
@@ -1,0 +1,65 @@
+from adafruit_blinka.microcontroller.generic_linux.libgpiod_pin import Pin
+
+PB0 = Pin(32)
+UART2_TX = PB0
+PB1 = Pin(33)
+UART2_RX = PB1
+PB2 = Pin(34)
+PB3 = Pin(35)
+PB4 = Pin(36)
+PB5 = Pin(37)
+PB6 = Pin(38)
+PB7 = Pin(39)
+
+PC4 = Pin(68)
+
+PD0 = Pin(96)
+UART3_TX = PD0
+SPI1_CS = PD0
+PD1 = Pin(97)
+SPI1_SCLK = PD1
+UART3_RX = PD1
+PD2 = Pin(98)
+UART4_TX = PD2
+SPI1_MOSI = PD2
+PD3 = Pin(99)
+UART4_RX = PD3
+SPI1_MISO = PD3
+PD4 = Pin(100)
+PD5 = Pin(101)
+PD6 = Pin(102)
+
+PE14 = Pin(142)
+TWI2_SCL = PE14
+PE15 = Pin(143)
+TWI2_SDA = PE15
+
+PH2 = Pin(226)
+TWI1_SCL = PH2
+PH3 = Pin(227)
+TWI1_SDA = PH3
+PH4 = Pin(228)
+PH5 = Pin(229)
+PH6 = Pin(230)
+
+PL2 = Pin(354)
+PL3 = Pin(355)
+PL9 = Pin(361)
+PL10 = Pin(362)
+
+# ordered as i2cId, sclId, sdaId
+i2cPorts = (
+    (1, TWI1_SCL, TWI1_SDA),
+    (2, TWI2_SCL, TWI2_SDA)
+)
+
+# ordered as spiId, sckId, mosiId, misoId
+spiPorts = (
+    (1, SPI1_SCLK, SPI1_MOSI, SPI1_MISO),
+)
+# ordered as uartId, txId, rxId
+uartPorts = (
+    (2, UART2_TX, UART2_RX),
+    (3, UART3_TX, UART3_RX),
+    (4, UART4_TX, UART4_RX),
+)

--- a/src/adafruit_blinka/microcontroller/allwinner/h3/__init__.py
+++ b/src/adafruit_blinka/microcontroller/allwinner/h3/__init__.py
@@ -1,0 +1,1 @@
+"""Definition for the AllWinner H3 chip"""

--- a/src/adafruit_blinka/microcontroller/allwinner/h3/pin.py
+++ b/src/adafruit_blinka/microcontroller/allwinner/h3/pin.py
@@ -55,8 +55,15 @@ PG12 = Pin(204)
 PG13 = Pin(205)
 
 
-i2cPorts = ( (0, TWI0_SCL, TWI0_SDA), )
+i2cPorts = (
+    (0, TWI0_SCL, TWI0_SDA),
+)
 # ordered as spiId, sckId, mosiId, misoId
-spiPorts = ( (0, SPI0_SCLK, SPI0_MOSI, SPI0_MISO), (1, SPI1_SCLK, SPI1_MOSI, SPI1_MISO), )
+spiPorts = (
+    (0, SPI0_SCLK, SPI0_MOSI, SPI0_MISO),
+    (1, SPI1_SCLK, SPI1_MOSI, SPI1_MISO),
+)
 # ordered as uartId, txId, rxId
-uartPorts = ( (3, UART3_TX, UART3_RX), )
+uartPorts = (
+    (3, UART3_TX, UART3_RX),
+)

--- a/src/busio.py
+++ b/src/busio.py
@@ -128,7 +128,7 @@ class SPI(Lockable):
             from adafruit_blinka.microcontroller.am335x.pin import Pin
             from adafruit_blinka.microcontroller.generic_linux.spi import SPI as _SPI
         elif board_id == ap_board.ORANGE_PI_PC or board_id == ap_board.ORANGE_PI_R1 or board_id == ap_board.ORANGE_PI_ZERO:
-            from adafruit_blinka.microcontroller.allwinner_h3.pin import Pin
+            from adafruit_blinka.microcontroller.allwinner.h3.pin import Pin
             from adafruit_blinka.microcontroller.generic_linux.spi import SPI as _SPI
         elif board_id == ap_board.GIANT_BOARD:
             from adafruit_blinka.microcontroller.sama5.pin import Pin

--- a/src/digitalio.py
+++ b/src/digitalio.py
@@ -16,7 +16,7 @@ if detector.chip.BCM2XXX:
 elif detector.chip.AM33XX:
     from adafruit_blinka.microcontroller.am335x.pin import Pin
 elif detector.chip.SUN8I:
-    from adafruit_blinka.microcontroller.allwinner_h3.pin import Pin
+    from adafruit_blinka.microcontroller.allwinner.h3.pin import Pin
 elif detector.chip.SAMA5:
     from adafruit_blinka.microcontroller.sama5.pin import Pin
 elif detector.chip.T210:

--- a/src/microcontroller/__init__.py
+++ b/src/microcontroller/__init__.py
@@ -33,7 +33,7 @@ elif chip_id == ap_chip.BCM2XXX:
 elif chip_id == ap_chip.AM33XX:
     from adafruit_blinka.microcontroller.am335x import *
 elif chip_id == ap_chip.SUN8I:
-    from adafruit_blinka.microcontroller.allwinner_h3 import *
+    from adafruit_blinka.microcontroller.allwinner.h3 import *
 elif chip_id == ap_chip.SAMA5:
     from adafruit_blinka.microcontroller.sama5 import *
 elif chip_id == ap_chip.T210:

--- a/src/microcontroller/pin.py
+++ b/src/microcontroller/pin.py
@@ -15,7 +15,7 @@ elif chip_id == ap_chip.BCM2XXX:
 elif chip_id == ap_chip.AM33XX:
     from adafruit_blinka.microcontroller.am335x.pin import *
 elif chip_id == ap_chip.SUN8I:
-    from adafruit_blinka.microcontroller.allwinner_h3.pin import *
+    from adafruit_blinka.microcontroller.allwinner.h3.pin import *
 elif chip_id == ap_chip.SAMA5:
     from adafruit_blinka.microcontroller.sama5.pin import *
 elif chip_id == ap_chip.T210:


### PR DESCRIPTION
Hey there!

Sorry if this PR comes out of the blue but I'm making this refactor in order to have all `AllWinner` chip defined within the same module for further implementations.

I'm planning to add the `A64` on it after the PR pending on the `Adafruit_Python_PlatformDetect` library is merged.

Regards.

P.D: I know nobody asked about this PR but IMHO seems like more organized as in the `amlogic` one.