### PR TITLE
FT232H updates for pyftdi API changes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ RPi.GPIO; platform_machine=='armv7l' or platform_machine=='armv6l'
 rpi_ws281x>=4.0.0; platform_machine=='armv7l' or platform_machine=='armv6l'
 spidev>=3.4; sys_platform == 'linux' and platform_machine!='mips'
 sysv_ipc; sys_platform == 'linux' and platform_machine!='mips'
-pyftdi>=0.30.0
+pyftdi>=0.40.0
 binho-host-adapter>=0.1.4

--- a/src/adafruit_blinka/microcontroller/ft232h/i2c.py
+++ b/src/adafruit_blinka/microcontroller/ft232h/i2c.py
@@ -32,6 +32,6 @@ class I2C:
         port = self._i2c.get_port(address)
         result = port.exchange(buffer_out[out_start:out_end],
                                in_end-in_start,
-                               relax=True).tobytes()
+                               relax=True)
         for i, b in enumerate(result):
             buffer_in[in_start+i] = b


### PR DESCRIPTION
Fix for #208 

pyftdi made API breaking changes at version 0.40.0 ([more info](https://eblot.github.io/pyftdi/index.html#major-changes)). This PR updates requirements to force to new API version and updates Blinka to use it.

Tested with a TSL2591:
```python
$ python3
Python 3.6.9 (default, Nov  7 2019, 10:44:02) 
[GCC 8.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import board
>>> import adafruit_tsl2591
>>> tsl = adafruit_tsl2591.TSL2591(board.I2C())
>>> tsl.lux
326.82431999999994
```