### PR TITLE
Add Orange Pi boards (One, Lite, PC Plus, Plus 2E)

### DIFF
--- a/src/board.py
+++ b/src/board.py
@@ -76,6 +76,18 @@ elif board_id == ap_board.ORANGE_PI_R1:
 elif board_id == ap_board.ORANGE_PI_ZERO:
     from adafruit_blinka.board.orangepizero import *
 
+elif board_id == ap_board.ORANGE_PI_ONE:
+    from adafruit_blinka.board.orangepipc import *
+
+elif board_id == ap_board.ORANGE_PI_PC_PLUS:
+    from adafruit_blinka.board.orangepipc import *
+
+elif board_id == ap_board.ORANGE_PI_LITE:
+    from adafruit_blinka.board.orangepipc import *
+
+elif board_id == ap_board.ORANGE_PI_PLUS_2E:
+    from adafruit_blinka.board.orangepipc import *
+
 elif board_id == ap_board.GIANT_BOARD:
     from adafruit_blinka.board.giantboard import *
 


### PR DESCRIPTION
I'm adding the some boards from Orange Pi which have the same chip (H3) as the one already defined.

Since the pinout is the same as the Orange Pi PC was easy to just import it when one of the boards added into Adafruit_PlatformDetect.

This PR correspond to issue #226 

If any change is needed, just let me know.