### PR TITLE
Temporarily point to older platform detect

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Adafruit-PlatformDetect
+Adafruit-PlatformDetect==1.4.5
 Adafruit-PureIO
 Jetson.GPIO; platform_machine=='aarch64'
 RPi.GPIO; platform_machine=='armv7l' or platform_machine=='armv6l'

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     py_modules=['_bleio', 'analogio', 'bitbangio', 'board', 'busio', 'digitalio', 'micropython', 'pulseio', 'neopixel_write'],
     package_data={'adafruit_blinka.microcontroller.bcm283x.pulseio': ['libgpiod_pulsein']},
     install_requires=[
-        "Adafruit-PlatformDetect",
+        "Adafruit-PlatformDetect==1.4.5",
         "Adafruit-PureIO",
         "spidev>=3.4; sys_platform=='linux' and platform_machine!='mips'",
         "sysv_ipc; platform_system != 'Windows' and platform_machine != 'mips'",


### PR DESCRIPTION
Released a refactored Platform Detect only to discover the Blinka-side PR was broken, so temporarily pointing to last working Blinka version.