### PR TITLE
Changed FT232H search url

### DIFF
--- a/src/adafruit_blinka/microcontroller/ft232h/i2c.py
+++ b/src/adafruit_blinka/microcontroller/ft232h/i2c.py
@@ -6,7 +6,7 @@ class I2C:
         # change GPIO controller to I2C
         from pyftdi.i2c import I2cController
         self._i2c = I2cController()
-        self._i2c.configure('ftdi:///1', frequency=frequency)
+        self._i2c.configure('ftdi://ftdi:ft232h/1', frequency=frequency)
         Pin.ft232h_gpio = self._i2c.get_gpio()
 
     def scan(self):

--- a/src/adafruit_blinka/microcontroller/ft232h/pin.py
+++ b/src/adafruit_blinka/microcontroller/ft232h/pin.py
@@ -14,7 +14,7 @@ class Pin:
         if not Pin.ft232h_gpio:
             from pyftdi.i2c import I2cController
             i2c = I2cController()
-            i2c.configure("ftdi:///1")
+            i2c.configure("ftdi://ftdi:ft232h/1")
             Pin.ft232h_gpio = i2c.get_gpio()
         # check if pin is valid
         if pin_id:

--- a/src/adafruit_blinka/microcontroller/ft232h/spi.py
+++ b/src/adafruit_blinka/microcontroller/ft232h/spi.py
@@ -6,7 +6,7 @@ class SPI:
     def __init__(self):
         from pyftdi.spi import SpiController
         self._spi = SpiController(cs_count=1)
-        self._spi.configure('ftdi:///1')
+        self._spi.configure('ftdi://ftdi:ft232h/1')
         self._port = self._spi.get_port(0)
         self._port.set_frequency(100000)
         self._port._cpol = 0


### PR DESCRIPTION
By changing the search URL to ftdi://ftdi:ft232h/1, pyftdi will open the first ft232h it finds, rather than the first ftdi device it finds. This is useful when other usb-serial converters are in use in addition to the ft232h.

Fixes issue #227 