### PR TITLE
Added Beaglebone Black Wireless as a device.

### DIFF
--- a/src/board.py
+++ b/src/board.py
@@ -66,7 +66,8 @@ elif board_id == ap_board.BEAGLEBONE_BLACK_INDUSTRIAL:
 
 elif board_id == ap_board.BEAGLEBONE_GREEN_WIRELESS:
     from adafruit_blinka.board.beagleboard.beaglebone_black import *
-
+elif board_id == ap_board.BEAGLEBONE_BLACK_WIRELESS:
+    from adafruit_blinka.board.beagleboard.beaglebone_black import *
 elif board_id == ap_board.BEAGLEBONE_POCKETBEAGLE:
     from adafruit_blinka.board.beagleboard.beaglebone_pocketbeagle import *
 


### PR DESCRIPTION
Beaglebone black wireless was not supported as a device, but I am using it with i2c on my beaglebone black wireless by simply adding it as a possible device.