### PR TITLE
Add Clockwork Pi board

### DIFF
--- a/src/adafruit_blinka/board/clockworkcpi3.py
+++ b/src/adafruit_blinka/board/clockworkcpi3.py
@@ -1,0 +1,33 @@
+"""Pin definitions for the Clockwork Pi (CPI3) board."""
+
+from adafruit_blinka.microcontroller.allwinner.a33 import pin
+
+# Clockwork Pi GPIO port (DEBUG section in datasheet)
+
+# Type 	Pin # (ext.) 	Pin # (Package) 	Function 1 	Function 2 	Pin # (sysfs) 	Color
+# 3V0 	1 											blue
+# GPIO 	2 		PB0 			UART0/2_TX 	PB-EINT0 	32 		green
+# GPIO 	3 		PB1 			UART0/2_RX 	PB-EINT1 	33 		yellow
+# GND 	4 											white
+# GPIO 	5 		PH5 			I2C1-SDA 			229 		red
+# GPIO 	6 		PH4 			I2C1-SCL 			228 		brown
+# GND 	7 											black
+# GPIO 	8 		PH6 			UART3-TX 	SPI0-CS 	230 		blue
+# GPIO	9 		PH7 			UART3-RX 	SPI0-CLK 	231 		green
+# GPIO 	10 		PH9 			UART3-CTS 	SPI0-MISO 	233 		yellow
+# GPIO 	11 		PH8 			UART3-RTS 	SPI0-MOSI 	232 		white
+# GND 	12 											red
+# 5V0 	13 											brown
+# 5V0 	14 											black
+
+PB0 = pin.PB0
+PB1 = pin.PB1
+TX = PB0
+RX = PB1
+
+SCL = pin.PH4
+SDA = pin.PH5
+
+SCLK = pin.PH7
+MOSI = pin.PH8
+MISO = pin.PH9

--- a/src/adafruit_blinka/microcontroller/allwinner/a33/__init__.py
+++ b/src/adafruit_blinka/microcontroller/allwinner/a33/__init__.py
@@ -1,0 +1,1 @@
+"""Definition for the AllWinner A33 chip"""

--- a/src/adafruit_blinka/microcontroller/allwinner/a33/pin.py
+++ b/src/adafruit_blinka/microcontroller/allwinner/a33/pin.py
@@ -1,0 +1,49 @@
+from adafruit_blinka.microcontroller.generic_linux.libgpiod_pin import Pin
+
+PB0 = Pin(32) # PB0/UART2_TX/UART0_TX/PB_EINT0
+UART2_TX = PB0
+PB1 = Pin(33) # PB1/UART2_RX/UART0_RX/PB_EINT1
+UART2_RX = PB1
+
+PC0 = Pin(64) # PC0/ND_WE/SPI0_MOSI
+PC1 = Pin(65) # PC1/ND_ALE/SPI0_MISO
+PC2 = Pin(66) # PC2/ND_CLE/SPI0_CLK
+
+PH4 = Pin(228) # PH4/TWI1_SCK
+TWI1_SCL = PH4
+PH5 = Pin(229) # PH5/TWI1_SDA
+TWI1_SDA = PH5
+
+
+PH6 = Pin(230) # PH6/SPI0_CS/UART3_TX
+UART3_TX = PH6
+SPI0_CS = PH6
+
+PH7 = Pin(231) # PH7/SPI0_CLK/UART3_RX
+UART3_RX = PH7
+SPI0_SCLK = PH7
+
+PH8 = Pin(232) # PH8/SPI0_MOSI/UART3_RTS
+UART3_RTS = PH8
+SPI0_MOSI = PH8
+
+PH9 = Pin(233) # PH9/SPI0_MISO/UART3_CTS
+UART3_CTS = PH9
+SPI0_MISO = PH9
+
+
+# ordered as i2cId, sclId, sdaId
+i2cPorts = (
+    (0, TWI1_SCL, TWI1_SDA),
+)
+
+# ordered as spiId, sckId, mosiId, misoId
+spiPorts = (
+    (0, SPI0_SCLK, SPI0_MOSI, SPI0_MISO),
+)
+
+# ordered as uartId, txId, rxId
+uartPorts = (
+    (2, UART2_TX, UART2_RX),
+    (3, UART3_TX, UART3_RX),
+)

--- a/src/board.py
+++ b/src/board.py
@@ -140,6 +140,9 @@ elif board_id == ap_board.SIFIVE_UNLEASHED:
 elif board_id == ap_board.PINE64:
     from adafruit_blinka.board.pine64 import *
 
+elif board_id == ap_board.CLOCKWORK_CPI3:
+    from adafruit_blinka.board.clockworkcpi3 import *
+
 elif "sphinx" in sys.modules:
     pass
 

--- a/src/busio.py
+++ b/src/busio.py
@@ -175,7 +175,9 @@ class SPI(Lockable):
         elif board_id == ap_board.PINE64 or board_id == ap_board.PINEBOOK or board_id == ap_board.PINEPHONE:
             from adafruit_blinka.microcontroller.allwinner.a64.pin import Pin
             from adafruit_blinka.microcontroller.generic_linux.spi import SPI as _SPI
-
+        elif board_id == ap_board.CLOCKWORK_CPI3:
+            from adafruit_blinka.microcontroller.allwinner.a33.pin import Pin
+            from adafruit_blinka.microcontroller.generic_linux.spi import SPI as _SPI
         else:
             from machine import SPI as _SPI
             from machine import Pin

--- a/src/digitalio.py
+++ b/src/digitalio.py
@@ -39,6 +39,8 @@ elif detector.chip.HFU540:
     from adafruit_blinka.microcontroller.hfu540.pin import Pin
 elif detector.chip.A64:
     from adafruit_blinka.microcontroller.allwinner.a64.pin import Pin
+elif detector.chip.A33:
+    from adafruit_blinka.microcontroller.allwinner.a33.pin import Pin
 elif detector.board.ftdi_ft232h:
     from adafruit_blinka.microcontroller.ft232h.pin import Pin
 elif detector.board.binho_nova:

--- a/src/microcontroller/__init__.py
+++ b/src/microcontroller/__init__.py
@@ -52,6 +52,8 @@ elif chip_id == ap_chip.APQ8016:
     from adafruit_blinka.microcontroller.snapdragon.apq8016.pin import *
 elif chip_id == ap_chip.A64:
     from adafruit_blinka.microcontroller.allwinner.a64.pin import *
+elif chip_id == ap_chip.A33:
+    from adafruit_blinka.microcontroller.allwinner.a33.pin import *
 elif chip_id == ap_chip.IMX8MX:
     from adafruit_blinka.microcontroller.nxp_imx8m import *
 elif chip_id == ap_chip.HFU540:

--- a/src/microcontroller/pin.py
+++ b/src/microcontroller/pin.py
@@ -44,6 +44,8 @@ elif chip_id == ap_chip.MCP2221:
     from adafruit_blinka.microcontroller.mcp2221.pin import *
 elif chip_id == ap_chip.A64:
     from adafruit_blinka.microcontroller.allwinner.a64.pin import *
+elif chip_id == ap_chip.A33:
+    from adafruit_blinka.microcontroller.allwinner.a33.pin import *
 elif chip_id == ap_chip.MIPS24KC:
     from adafruit_blinka.microcontroller.atheros.ar9331.pin import *
 else:


### PR DESCRIPTION
The Clockwork Pi Gameshell is a hackable retro gaming device which exposes some GPIO/I2C/SPI ports and runs on a Allwinner R16/A33 SoC.