### PR TITLE
Add fake pin numbers for raspi to allow selecting explicit i2c bus

### DIFF
--- a/src/adafruit_blinka/board/raspberrypi/raspi_1b_rev1.py
+++ b/src/adafruit_blinka/board/raspberrypi/raspi_1b_rev1.py
@@ -35,3 +35,31 @@ D22 = pin.D22
 D23 = pin.D23
 D24 = pin.D24
 D25 = pin.D25
+
+# Fake pin numbers to explicitly reference I2C bus devices (/dev/i2c-n) that may
+# or may not be backed by specific physical pins (like virtual i2c buses from i2c-mux)
+# eg: to reference i2c bus 5 (/dev/i2c-5), use SCL5 and SDA5
+SDA0 = pin.SDA0
+SDA1 = pin.SDA1
+SDA2 = pin.SDA2
+SDA3 = pin.SDA3
+SDA4 = pin.SDA4
+SDA5 = pin.SDA5
+SDA6 = pin.SDA6
+SDA7 = pin.SDA7
+SDA8 = pin.SDA8
+SDA9 = pin.SDA9
+SDA10 = pin.SDA10
+SDA11 = pin.SDA11
+SCL0 = pin.SCL0
+SCL1 = pin.SCL1
+SCL2 = pin.SCL2
+SCL3 = pin.SCL3
+SCL4 = pin.SCL4
+SCL5 = pin.SCL5
+SCL6 = pin.SCL6
+SCL7 = pin.SCL7
+SCL8 = pin.SCL8
+SCL9 = pin.SCL9
+SCL10 = pin.SCL10
+SCL11 = pin.SCL11

--- a/src/adafruit_blinka/board/raspberrypi/raspi_1b_rev2.py
+++ b/src/adafruit_blinka/board/raspberrypi/raspi_1b_rev2.py
@@ -35,3 +35,31 @@ D23 = pin.D23
 D24 = pin.D24
 D25 = pin.D25
 D27 = pin.D27
+
+# Fake pin numbers to explicitly reference I2C bus devices (/dev/i2c-n) that may
+# or may not be backed by specific physical pins (like virtual i2c buses from i2c-mux)
+# eg: to reference i2c bus 5 (/dev/i2c-5), use SCL5 and SDA5
+SDA0 = pin.SDA0
+SDA1 = pin.SDA1
+SDA2 = pin.SDA2
+SDA3 = pin.SDA3
+SDA4 = pin.SDA4
+SDA5 = pin.SDA5
+SDA6 = pin.SDA6
+SDA7 = pin.SDA7
+SDA8 = pin.SDA8
+SDA9 = pin.SDA9
+SDA10 = pin.SDA10
+SDA11 = pin.SDA11
+SCL0 = pin.SCL0
+SCL1 = pin.SCL1
+SCL2 = pin.SCL2
+SCL3 = pin.SCL3
+SCL4 = pin.SCL4
+SCL5 = pin.SCL5
+SCL6 = pin.SCL6
+SCL7 = pin.SCL7
+SCL8 = pin.SCL8
+SCL9 = pin.SCL9
+SCL10 = pin.SCL10
+SCL11 = pin.SCL11

--- a/src/adafruit_blinka/board/raspberrypi/raspi_40pin.py
+++ b/src/adafruit_blinka/board/raspberrypi/raspi_40pin.py
@@ -53,3 +53,31 @@ D24 = pin.D24
 D25 = pin.D25
 D26 = pin.D26
 D27 = pin.D27
+
+# Fake pin numbers to explicitly reference I2C bus devices (/dev/i2c-n) that may
+# or may not be backed by specific physical pins (like virtual i2c buses from i2c-mux)
+# eg: to reference i2c bus 5 (/dev/i2c-5), use SCL5 and SDA5
+SDA0 = pin.SDA0
+SDA1 = pin.SDA1
+SDA2 = pin.SDA2
+SDA3 = pin.SDA3
+SDA4 = pin.SDA4
+SDA5 = pin.SDA5
+SDA6 = pin.SDA6
+SDA7 = pin.SDA7
+SDA8 = pin.SDA8
+SDA9 = pin.SDA9
+SDA10 = pin.SDA10
+SDA11 = pin.SDA11
+SCL0 = pin.SCL0
+SCL1 = pin.SCL1
+SCL2 = pin.SCL2
+SCL3 = pin.SCL3
+SCL4 = pin.SCL4
+SCL5 = pin.SCL5
+SCL6 = pin.SCL6
+SCL7 = pin.SCL7
+SCL8 = pin.SCL8
+SCL9 = pin.SCL9
+SCL10 = pin.SCL10
+SCL11 = pin.SCL11

--- a/src/adafruit_blinka/board/raspberrypi/raspi_cm.py
+++ b/src/adafruit_blinka/board/raspberrypi/raspi_cm.py
@@ -72,3 +72,31 @@ SCK_2 = pin.D43
 D43 = pin.D43
 D44 = pin.D44
 D45 = pin.D45
+
+# Fake pin numbers to explicitly reference I2C bus devices (/dev/i2c-n) that may
+# or may not be backed by specific physical pins (like virtual i2c buses from i2c-mux)
+# eg: to reference i2c bus 5 (/dev/i2c-5), use SCL5 and SDA5
+SDA0 = pin.SDA0
+SDA1 = pin.SDA1
+SDA2 = pin.SDA2
+SDA3 = pin.SDA3
+SDA4 = pin.SDA4
+SDA5 = pin.SDA5
+SDA6 = pin.SDA6
+SDA7 = pin.SDA7
+SDA8 = pin.SDA8
+SDA9 = pin.SDA9
+SDA10 = pin.SDA10
+SDA11 = pin.SDA11
+SCL0 = pin.SCL0
+SCL1 = pin.SCL1
+SCL2 = pin.SCL2
+SCL3 = pin.SCL3
+SCL4 = pin.SCL4
+SCL5 = pin.SCL5
+SCL6 = pin.SCL6
+SCL7 = pin.SCL7
+SCL8 = pin.SCL8
+SCL9 = pin.SCL9
+SCL10 = pin.SCL10
+SCL11 = pin.SCL11

--- a/src/adafruit_blinka/microcontroller/bcm283x/pin.py
+++ b/src/adafruit_blinka/microcontroller/bcm283x/pin.py
@@ -137,6 +137,34 @@ D43 = Pin(43)
 D44 = Pin(44)
 D45 = Pin(45)
 
+# Let's use fake pin numbers in 5xx range to explicitly reference I2C bus devices (/dev/i2c-n) that
+# may or may not be backed by specific physical pins (like virtual i2c buses from i2c-mux)
+# eg: to reference i2c bus 5 (/dev/i2c-5), use SCL5 and SDA5
+SDA0 = Pin(500)
+SDA1 = Pin(501)
+SDA2 = Pin(502)
+SDA3 = Pin(503)
+SDA4 = Pin(504)
+SDA5 = Pin(505)
+SDA6 = Pin(506)
+SDA7 = Pin(507)
+SDA8 = Pin(508)
+SDA9 = Pin(509)
+SDA10 = Pin(510)
+SDA11 = Pin(511)
+SCL0 = Pin(550)
+SCL1 = Pin(551)
+SCL2 = Pin(552)
+SCL3 = Pin(553)
+SCL4 = Pin(554)
+SCL5 = Pin(555)
+SCL6 = Pin(556)
+SCL7 = Pin(557)
+SCL8 = Pin(558)
+SCL9 = Pin(559)
+SCL10 = Pin(560)
+SCL11 = Pin(561)
+
 # ordered as spiId, sckId, mosiId, misoId
 spiPorts = (
     (0, SCLK, MOSI, MISO),
@@ -148,7 +176,18 @@ spiPorts = (
 uartPorts = ((1, TXD, RXD),)
 
 i2cPorts = (
-    (3, SCL, SDA),
+    (11, SCL11, SDA11),
+    (10, SCL10, SDA10),
+    (9, SCL9, SDA9),
+    (8, SCL8, SDA8),
+    (7, SCL7, SDA7),
+    (6, SCL6, SDA6),
+    (5, SCL5, SDA5),
+    (4, SCL4, SDA4),
+    (3, SCL3, SDA3),
+    (2, SCL2, SDA2),
+    (1, SCL1, SDA1),
+    (0, SCL0, SDA0),
     (1, SCL, SDA),
     (0, D1, D0),  # both pi 1 and pi 2 i2c ports!
 )


### PR DESCRIPTION
This will allow explicit selection of a specific i2c bus device.  For example, to reference i2c bus 5 (/dev/i2c-5), use pin references SCL5 and SDA5.

Also, fixes #241 by reverting (part of) previous solution (PR #190) of attempting to auto-choose between i2c-1 and i2c-3 using SCL/SDA pin references.  This PR restores the prior behavior of SCL/SDA (which looks to use i2c-1 or i2c-0 depending on the rpi model) and provides an alternate solution for using i2c-3 (via explicit SCL3/SDA3 pin references).  This should hopefully preserve functionality of all existing code (except for any written in the last few months that was using SCL/SDA to select bus i2c-3) while adding flexibility to specify any particular i2c bus (up to i2c-11) for those who have the need.

I've tested this to talk to 8 SSD1306 OLED displays on i2c-3 through i2c-10 via a TCA9548A multiplexer hanging off of i2c-1 on a raspi zero w.  I also tested examples/pi_busio_i2c.py to talk to an MCP9808 without i2c-mux loaded.