### PR TITLE
Add Orange PI 2 support

### DIFF
--- a/src/board.py
+++ b/src/board.py
@@ -92,6 +92,9 @@ elif board_id == ap_board.ORANGE_PI_LITE:
 elif board_id == ap_board.ORANGE_PI_PLUS_2E:
     from adafruit_blinka.board.orangepi.orangepipc import *
 
+elif board_id == ap_board.ORANGE_PI_2:
+    from adafruit_blinka.board.orangepi.orangepipc import *
+
 elif board_id == ap_board.GIANT_BOARD:
     from adafruit_blinka.board.giantboard import *
 


### PR DESCRIPTION
Add support for the Orange PI 2 using the existing orange pi pc class.

Depends on https://github.com/adafruit/Adafruit_Python_PlatformDetect/pull/75 