### PR TITLE
Set checkout repo to V2 since it fixes an issue

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       run: |
         python3 --version
     - name: Checkout Current Repo
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
       with:
         submodules: true
     - name: Checkout tools repo


### PR DESCRIPTION
PR #282 is running into an issue with the following error message:
```
##[error]fatal: reference is not a tree: 539962c4c3c088797d02202922a9c51534b77bdf
##[error]Git checkout failed with exit code: 128
##[error]Exit code 1 returned from process: file name '/home/runner/runners/2.169.1/bin/Runner.PluginHost', arguments 'action "GitHub.Runner.Plugins.Repository.v1_0.CheckoutTask, Runner.Plugins"'.
```

According to https://github.com/actions/checkout/issues/23, this particular issue is fixed in V2, so this PR makes it use V2.