### PR TITLE
Using SPI1 on Beaglebone Black

### DIFF
--- a/src/adafruit_blinka/microcontroller/am335x/pin.py
+++ b/src/adafruit_blinka/microcontroller/am335x/pin.py
@@ -330,8 +330,8 @@ UART5_CTSn = Pin("UART5_CTSn")
 
 # ordered as spiId, sckId, mosiId, misoId
 spiPorts = (
-    (1, SPI0_SCLK, SPI0_D1, SPI0_D0),
-    (2, SPI1_SCLK, SPI1_D1, SPI1_D0),
+    (0, SPI0_SCLK, SPI0_D1, SPI0_D0),
+    (1, SPI1_SCLK, SPI1_D1, SPI1_D0),
 )
 
 # ordered as uartId, txId, rxId


### PR DESCRIPTION
I attached a MAX31865 to BB. However, the existing code was attempting to open /dev/spidev2.0 whilst the correct device has to be /dev/spidev1.0

I traced the issue to the spiPorts being enumerated as 1 and 2, rather than 0 and 1