### PR TITLE
Adding PineH64 SBC support 

### DIFF
--- a/src/adafruit_blinka/board/pineH64.py
+++ b/src/adafruit_blinka/board/pineH64.py
@@ -1,5 +1,5 @@
 """Pin definitions for the PineH64."""
- 
+
 from adafruit_blinka.microcontroller.allwinner.h6 import pin
 
 D2 = pin.PD26
@@ -27,16 +27,15 @@ D24 = pin.PD17
 D25 = pin.PD18
 D26 = pin.PD23
 D27 = pin.PD14
- 
+
 SDA = D2
 SCL = D3
- 
+
 SCLK = D11
 MOSI = D10
 MISO = D9
 CS = D8
 SCK = SCLK
- 
+
 UART_TX = D14
 UART_RX = D15
- 

--- a/src/adafruit_blinka/board/pineH64.py
+++ b/src/adafruit_blinka/board/pineH64.py
@@ -1,0 +1,42 @@
+"""Pin definitions for the PineH64."""
+ 
+from adafruit_blinka.microcontroller.allwinner.h6 import pin
+
+D2 = pin.PD26
+D3 = pin.PD25
+D4 = pin.PL8
+D5 = pin.PH2
+D6 = pin.PG14
+D7 = pin.PC16
+D8 = pin.PH3
+D9 = pin.PH6
+D10 = pin.PH5
+D11 = pin.PH4
+D12 = pin.PD22
+D13 = pin.PD21
+D14 = pin.PD19
+D15 = pin.PD20
+D16 = pin.PD24
+D17 = pin.PL9
+D18 = pin.PG11
+D19 = pin.PG10
+D21 = pin.PG12
+D22 = pin.PG13
+D23 = pin.PD16
+D24 = pin.PD17
+D25 = pin.PD18
+D26 = pin.PD23
+D27 = pin.PD14
+ 
+SDA = D2
+SCL = D3
+ 
+SCLK = D11
+MOSI = D10
+MISO = D9
+CS = D8
+SCK = SCLK
+ 
+UART_TX = D14
+UART_RX = D15
+ 

--- a/src/adafruit_blinka/microcontroller/allwinner/h6/__init__.py
+++ b/src/adafruit_blinka/microcontroller/allwinner/h6/__init__.py
@@ -1,0 +1,1 @@
+"""Definition for the AllWinner H6 chip"""

--- a/src/adafruit_blinka/microcontroller/allwinner/h6/pin.py
+++ b/src/adafruit_blinka/microcontroller/allwinner/h6/pin.py
@@ -1,0 +1,47 @@
+"""Allwinner H6 Pin Names"""
+from adafruit_blinka.microcontroller.generic_linux.libgpiod_pin import Pin
+
+PC16 = Pin((1, 79))
+
+PD14 = Pin((1, 110))
+PD15 = Pin((1, 111))
+PD16 = Pin((1, 112))
+PD17 = Pin((1, 113))
+PD18 = Pin((1, 114))
+PD19 = Pin((1, 115))
+UART2_TX = PD19
+PD20 = Pin((1, 116))
+UART2_RX = PD20
+PD21 = Pin((1, 117))
+PD22 = Pin((1, 118))
+PD23 = Pin((1, 119))
+PD24 = Pin((1, 120))
+PD25 = Pin((1, 121))
+TWI0_SCL = PD25
+PD26 = Pin((1, 122))
+TWI0_SDA = PD26
+
+PG10 = Pin((1, 202))
+PG11 = Pin((1, 203))
+PG12 = Pin((1, 204))
+PG13 = Pin((1, 205))
+PG14 = Pin((1, 206))
+
+PH2 = Pin((1, 226))
+PH3 = Pin((1, 227))
+SPI1_CS = PH3
+PH4 = Pin((1, 228))
+SPI1_SCLK = PH4
+PH5 = Pin((1, 229))
+SPI1_MOSI = PH5
+PH6 = Pin((1, 230))
+SPI1_MISO = PH6
+PH8 = Pin((1, 230))
+PH9 = Pin((1, 231))
+
+PL8 = Pin((1, 360))
+PL9 = Pin((1, 361))
+
+i2cPorts = ((0, TWI0_SCL, TWI0_SDA),)
+spiPorts = ((0, SPI1_SCLK, SPI1_MOSI, SPI1_MISO),)
+uartPorts = ((2, UART2_TX, UART2_RX),)

--- a/src/board.py
+++ b/src/board.py
@@ -150,6 +150,9 @@ elif board_id == ap_board.SIFIVE_UNLEASHED:
 elif board_id == ap_board.PINE64:
     from adafruit_blinka.board.pine64 import *
 
+elif board_id == ap_board.PINEH64:
+    from adafruit_blinka.board.pineH64 import 
+
 elif board_id == ap_board.CLOCKWORK_CPI3:
     from adafruit_blinka.board.clockworkcpi3 import *
 

--- a/src/board.py
+++ b/src/board.py
@@ -151,7 +151,7 @@ elif board_id == ap_board.PINE64:
     from adafruit_blinka.board.pine64 import *
 
 elif board_id == ap_board.PINEH64:
-    from adafruit_blinka.board.pineH64 import 
+    from adafruit_blinka.board.pineH64 import *
 
 elif board_id == ap_board.CLOCKWORK_CPI3:
     from adafruit_blinka.board.clockworkcpi3 import *


### PR DESCRIPTION
I have added the "microcontroller" file and "board" file for the Allwinner H6 based PineH64. I believe these are the only necessary files for Blinka compatibility.

I followed the guide provided by Adafruit at the following link: 
https://learn.adafruit.com/adding-a-single-board-computer-to-blinka/

I will also be creating a pull request for adafruit_platformdetect to add PineH64 detection.