### PR TITLE
Fix FT232H SPI chunkification

### DIFF
--- a/src/adafruit_blinka/microcontroller/ft232h/spi.py
+++ b/src/adafruit_blinka/microcontroller/ft232h/spi.py
@@ -60,7 +60,8 @@ class SPI:
             chunk_end = chunk_start + self._spi.PAYLOAD_MAX_LENGTH
             self._port.write(buf[chunk_start:chunk_end])
         if rest:
-            self._port.write(buf[-1 * rest :])
+            rest_start = start + chunks * self._spi.PAYLOAD_MAX_LENGTH
+            self._port.write(buf[rest_start:end])
 
     # pylint: disable=unused-argument
     def readinto(self, buf, start=0, end=None, write_value=0):


### PR DESCRIPTION
For #326 

Re-running test from issue thread:
![ft232h_pr_1](https://user-images.githubusercontent.com/8755041/89693912-d2cc1080-d8c4-11ea-9d39-0d111567fbe8.jpg)

And to exercise things a little more:
```python
import board
import digitalio

BUFFER = bytearray([1,2,3,4,5,6,7,8,9,10,11,12,13,14,15])

spi = board.SPI()

cs = digitalio.DigitalInOut(board.C0)
cs.direction = digitalio.Direction.OUTPUT
cs.value = True

spi.try_lock()
cs.value = False
spi.write(BUFFER, start=6, end=11)
cs.value = True
spi.unlock()
```
![ft232h_pr_2](https://user-images.githubusercontent.com/8755041/89693932-e6777700-d8c4-11ea-9486-d34d39e6d436.jpg)
