### PR TITLE
Updated for STM32->STM32F405 PlatformDetect chip rename

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Adafruit-PlatformDetect>=2.11.1
+Adafruit-PlatformDetect>=2.15.1
 Adafruit-PureIO>=1.1.5
 Jetson.GPIO; platform_machine=='aarch64'
 RPi.GPIO; platform_machine=='armv7l' or platform_machine=='armv6l'

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setup(
         "adafruit_blinka.microcontroller.bcm283x.pulseio": ["libgpiod_pulsein"]
     },
     install_requires=[
-        "Adafruit-PlatformDetect>=2.11.1",
+        "Adafruit-PlatformDetect>=2.15.1",
         "Adafruit-PureIO>=1.1.5",
         "pyftdi>=0.40.0",
     ]

--- a/src/adafruit_blinka/board/pyboard.py
+++ b/src/adafruit_blinka/board/pyboard.py
@@ -1,6 +1,6 @@
 """PyBoard pin names"""
 
-from adafruit_blinka.microcontroller.stm32 import pin
+from adafruit_blinka.microcontroller.stm32.stm32f405 import pin
 
 X1 = pin.A0
 X2 = pin.A1

--- a/src/adafruit_blinka/microcontroller/stm32/stm32f405/pin.py
+++ b/src/adafruit_blinka/microcontroller/stm32/stm32f405/pin.py
@@ -1,4 +1,4 @@
-"""STM32 pins"""
+"""STM32F405 pins"""
 
 from microcontroller import Pin
 

--- a/src/digitalio.py
+++ b/src/digitalio.py
@@ -53,7 +53,7 @@ elif detector.board.binho_nova:
     from adafruit_blinka.microcontroller.nova.pin import Pin
 elif detector.board.greatfet_one:
     from adafruit_blinka.microcontroller.nxp_lpc4330.pin import Pin
-elif detector.chip.STM32:
+elif detector.chip.STM32F405:
     from machine import Pin
 elif detector.board.microchip_mcp2221:
     from adafruit_blinka.microcontroller.mcp2221.pin import Pin

--- a/src/microcontroller/__init__.py
+++ b/src/microcontroller/__init__.py
@@ -34,8 +34,8 @@ class Pin(Enum):
 
 if chip_id == ap_chip.ESP8266:
     from adafruit_blinka.microcontroller.esp8266 import *
-elif chip_id == ap_chip.STM32:
-    from adafruit_blinka.microcontroller.stm32 import *
+elif chip_id == ap_chip.STM32F405:
+    from adafruit_blinka.microcontroller.stm32.stm32f405 import *
 elif chip_id == ap_chip.BCM2XXX:
     from adafruit_blinka.microcontroller.bcm283x import *
 elif chip_id == ap_chip.AM33XX:

--- a/src/microcontroller/pin.py
+++ b/src/microcontroller/pin.py
@@ -8,8 +8,8 @@ from adafruit_blinka.agnostic import chip_id
 
 if chip_id == ap_chip.ESP8266:
     from adafruit_blinka.microcontroller.esp8266.pin import *
-elif chip_id == ap_chip.STM32:
-    from adafruit_blinka.microcontroller.stm32.pin import *
+elif chip_id == ap_chip.STM32F405:
+    from adafruit_blinka.microcontroller.stm32.stm32f405.pin import *
 elif chip_id == ap_chip.BCM2XXX:
     from adafruit_blinka.microcontroller.bcm283x.pin import *
 elif chip_id == ap_chip.AM33XX:


### PR DESCRIPTION
This will require https://github.com/adafruit/Adafruit_Python_PlatformDetect/pull/97 to be merged in and PlatformDetect release 2.15.1 to be performed before it will pass the checks.