### PR TITLE
Allow latest release of black to run

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
         source actions-ci/install.sh
     - name: Pip install pylint, black, & Sphinx
       run: |
-        pip install --force-reinstall pylint black==19.10b0 Sphinx sphinx-rtd-theme
+        pip install --force-reinstall pylint black Sphinx sphinx-rtd-theme
     - name: Library version
       run: git describe --dirty --always --tags
     - name: Check formatting

--- a/src/adafruit_blinka/__init__.py
+++ b/src/adafruit_blinka/__init__.py
@@ -8,8 +8,8 @@
 
 class Enum:
     """
-        Object supporting CircuitPython-style of static symbols
-        as seen with Direction.OUTPUT, Pull.UP
+    Object supporting CircuitPython-style of static symbols
+    as seen with Direction.OUTPUT, Pull.UP
     """
 
     def __repr__(self):
@@ -27,8 +27,8 @@ class Enum:
     @classmethod
     def iteritems(cls):
         """
-            Inspects attributes of the class for instances of the class
-            and returns as key,value pairs mirroring dict#iteritems
+        Inspects attributes of the class for instances of the class
+        and returns as key,value pairs mirroring dict#iteritems
         """
         for key in dir(cls):
             val = getattr(cls, key)

--- a/src/busio.py
+++ b/src/busio.py
@@ -127,7 +127,7 @@ class I2C(Lockable):
         in_end=None,
         stop=False
     ):
-        """"Write to a device at specified address from a buffer then read
+        """ "Write to a device at specified address from a buffer then read
         from a device at specified address into a buffer
         """
         return self._i2c.writeto_then_readfrom(

--- a/test/src/testing/adafruit_blinka.py
+++ b/test/src/testing/adafruit_blinka.py
@@ -3,8 +3,8 @@ import unittest
 
 class TestEnum(unittest.TestCase):
     """
-        Verifies the repl() and str() behaviour of an example Enum
-        Enums represent configuration values such as digitalio.Direction, digitalio.Pull etc.
+    Verifies the repl() and str() behaviour of an example Enum
+    Enums represent configuration values such as digitalio.Direction, digitalio.Pull etc.
     """
 
     def setUp(self):
@@ -24,7 +24,13 @@ class TestEnum(unittest.TestCase):
     def test_iteritems(self):
         """A subtype of Enum can list all attributes of its own type"""
         items = list(self.Cls.iteritems())
-        self.assertEqual(items, [("one", self.Cls.one), ("two", self.Cls.two),])
+        self.assertEqual(
+            items,
+            [
+                ("one", self.Cls.one),
+                ("two", self.Cls.two),
+            ],
+        )
 
     def test_repr(self):
         """A repr() call on an Enum gives its fully-qualified name"""


### PR DESCRIPTION
For some reason Black was still tied to an older version. This fixes it so it's like the other libraries.