### PR TITLE
Enable support for multiple mcp2221

### DIFF
--- a/examples/mcps_busio_i2c.py
+++ b/examples/mcps_busio_i2c.py
@@ -1,0 +1,30 @@
+import time
+import sys
+import board
+import busio
+
+print("hello blinka!")
+
+i2c = busio.I2C(board.SCL, board.SDA)
+
+print("I2C devices found: ", [hex(i) for i in i2c.scan()])
+
+if not 0x18 in i2c.scan():
+    print("Didn't find MCP9808")
+    sys.exit()
+
+
+def temp_c(data):
+    value = data[0] << 8 | data[1]
+    temp = (value & 0xFFF) / 16.0
+    if value & 0x1000:
+        temp -= 256.0
+    return temp
+
+
+while True:
+    i2c.writeto(0x18, bytes([0x05]), stop=False)
+    result = bytearray(2)
+    i2c.readfrom_into(0x18, result)
+    print(temp_c(result))
+    time.sleep(0.5)

--- a/examples/mcps_busio_i2c.py
+++ b/examples/mcps_busio_i2c.py
@@ -1,6 +1,4 @@
 import time
-import sys
-import board
 import busio
 import hid
 
@@ -8,8 +6,11 @@ from adafruit_blinka.microcontroller.mcp2221.mcp2221 import mcp2221 as _mcp2221
 from adafruit_blinka.microcontroller.mcp2221.mcp2221 import MCP2221 as _MCP2221
 from adafruit_blinka.microcontroller.mcp2221.i2c import I2C as _MCP2221I2C
 
+MLXADDR = 0x33
+ADDRID1 = 0x2407
 
-class MCP2221(_MCP2221): 
+
+class MCP2221(_MCP2221):
     def __init__(self, address):
         self._hid = hid.device()
         self._hid.open_path(address)
@@ -21,27 +22,36 @@ class MCP2221(_MCP2221):
 
 
 class MCP2221I2C(_MCP2221I2C):
-    def __init__(self, mcp2221, *, frequency=1000000):
+    def __init__(self, mcp2221, *, frequency=100000):
         self._mcp2221 = mcp2221
         self._mcp2221.i2c_configure(frequency)
 
 
 class I2C(busio.I2C):
-    def __init__(self, mcp2221_i2c, *, frequency=1000000):
+    def __init__(self, mcp2221_i2c):
         self._i2c = mcp2221_i2c
 
 
-def temp_c(data):
-    value = data[0] << 8 | data[1]
-    temp = (value & 0xFFF) / 16.0
-    if value & 0x1000:
-        temp -= 256.0
-    return temp
+addresses = [mcp["path"] for mcp in hid.enumerate(0x04D8, 0x00DD)]
+
+i2c_devices = []
+i2c_devices.append(I2C(MCP2221I2C(_mcp2221)))
+
+for addr in addresses:
+    try:
+        i2c_device = I2C(MCP2221I2C(MCP2221(addr)))
+        i2c_devices.append(i2c_device)
+    except OSError:
+        print("Device path: "+ str(addr)+ " is used")
 
 
 while True:
-    i2c.writeto(0x18, bytes([0x05]), stop=False)
-    result = bytearray(2)
-    i2c.readfrom_into(0x18, result)
-    print(temp_c(result))
-    time.sleep(0.5)
+    for i2c in i2c_devices:
+        addrbuf = bytearray(2)
+        addrbuf[0] = ADDRID1 >> 8
+        addrbuf[1] = ADDRID1 & 0xFF
+        inbuf  = bytearray(6)
+        i2c.writeto_then_readfrom(MLXADDR, addrbuf, inbuf)
+        print("Device "+str(i2c_devices.index(i2c))+": ")
+        print(inbuf)
+        time.sleep(0.5)

--- a/examples/mcps_busio_i2c.py
+++ b/examples/mcps_busio_i2c.py
@@ -14,7 +14,7 @@ class MCP2221(_MCP2221):
     def __init__(self, address):
         self._hid = hid.device()
         self._hid.open_path(address)
-        print("Connected to "+str(address))
+        print("Connected to " + str(address))
         self._gp_config = [0x07] * 4  # "don't care" initial value
         for pin in range(4):
             self.gp_set_mode(pin, self.GP_GPIO)  # set to GPIO mode
@@ -42,7 +42,7 @@ for addr in addresses:
         i2c_device = I2C(MCP2221I2C(MCP2221(addr)))
         i2c_devices.append(i2c_device)
     except OSError:
-        print("Device path: "+ str(addr)+ " is used")
+        print("Device path: " + str(addr) + " is used")
 
 
 while True:
@@ -50,8 +50,8 @@ while True:
         addrbuf = bytearray(2)
         addrbuf[0] = ADDRID1 >> 8
         addrbuf[1] = ADDRID1 & 0xFF
-        inbuf  = bytearray(6)
+        inbuf = bytearray(6)
         i2c.writeto_then_readfrom(MLXADDR, addrbuf, inbuf)
-        print("Device "+str(i2c_devices.index(i2c))+": ")
+        print("Device " + str(i2c_devices.index(i2c)) + ": ")
         print(inbuf)
         time.sleep(0.5)

--- a/examples/mcps_busio_i2c.py
+++ b/examples/mcps_busio_i2c.py
@@ -2,16 +2,33 @@ import time
 import sys
 import board
 import busio
+import hid
 
-print("hello blinka!")
+from adafruit_blinka.microcontroller.mcp2221.mcp2221 import mcp2221 as _mcp2221
+from adafruit_blinka.microcontroller.mcp2221.mcp2221 import MCP2221 as _MCP2221
+from adafruit_blinka.microcontroller.mcp2221.i2c import I2C as _MCP2221I2C
 
-i2c = busio.I2C(board.SCL, board.SDA)
 
-print("I2C devices found: ", [hex(i) for i in i2c.scan()])
+class MCP2221(_MCP2221): 
+    def __init__(self, address):
+        self._hid = hid.device()
+        self._hid.open_path(address)
+        print("Connected to "+str(address))
+        self._gp_config = [0x07] * 4  # "don't care" initial value
+        for pin in range(4):
+            self.gp_set_mode(pin, self.GP_GPIO)  # set to GPIO mode
+            self.gpio_set_direction(pin, 1)  # set to INPUT
 
-if not 0x18 in i2c.scan():
-    print("Didn't find MCP9808")
-    sys.exit()
+
+class MCP2221I2C(_MCP2221I2C):
+    def __init__(self, mcp2221, *, frequency=1000000):
+        self._mcp2221 = mcp2221
+        self._mcp2221.i2c_configure(frequency)
+
+
+class I2C(busio.I2C):
+    def __init__(self, mcp2221_i2c, *, frequency=1000000):
+        self._i2c = mcp2221_i2c
 
 
 def temp_c(data):

--- a/examples/mcps_busio_i2c.py
+++ b/examples/mcps_busio_i2c.py
@@ -1,6 +1,6 @@
 import time
-import busio
 import hid
+import busio
 
 from adafruit_blinka.microcontroller.mcp2221.mcp2221 import mcp2221 as _mcp2221
 from adafruit_blinka.microcontroller.mcp2221.mcp2221 import MCP2221 as _MCP2221

--- a/examples/mcps_busio_i2c.py
+++ b/examples/mcps_busio_i2c.py
@@ -10,7 +10,7 @@ MLXADDR = 0x33
 ADDRID1 = 0x2407
 
 
-class MCP2221(_MCP2221):
+class MCP2221(_MCP2221):  # pylint: disable=too-few-public-methods
     def __init__(self, address):
         self._hid = hid.device()
         self._hid.open_path(address)
@@ -21,13 +21,13 @@ class MCP2221(_MCP2221):
             self.gpio_set_direction(pin, 1)  # set to INPUT
 
 
-class MCP2221I2C(_MCP2221I2C):
+class MCP2221I2C(_MCP2221I2C):  # pylint: disable=too-few-public-methods
     def __init__(self, mcp2221, *, frequency=100000):
         self._mcp2221 = mcp2221
         self._mcp2221.i2c_configure(frequency)
 
 
-class I2C(busio.I2C):
+class I2C(busio.I2C):  # pylint: disable=too-few-public-methods
     def __init__(self, mcp2221_i2c):
         self._i2c = mcp2221_i2c
 


### PR DESCRIPTION
I am working on a project which requires the use of multiple MCP2221 + MLX90640 on a single host. It looked like it was not possible with the current code, so I made this example which shows how it can be accomplished without modifying any code of this library. You can then create different I2C objects independently, in my case MLX90640, and use them normally.

- Redefine existing classes to be able to connect with device path
- Use MCP2221 which is created on import.
- Connect to other MCP2221, if any.
- Print ids (made for mlx90640)

