### PR TITLE
add option to skip reset on MCP2221

### DIFF
--- a/src/adafruit_blinka/microcontroller/mcp2221/mcp2221.py
+++ b/src/adafruit_blinka/microcontroller/mcp2221/mcp2221.py
@@ -6,7 +6,7 @@ import hid
 
 # Here if you need it
 MCP2221_HID_DELAY = float(os.environ.get("BLINKA_MCP2221_HID_DELAY", 0))
-# Use to set delay between reset and device reopen
+# Use to set delay between reset and device reopen. if negative, don't reset at all
 MCP2221_RESET_DELAY = float(os.environ.get("BLINKA_MCP2221_RESET_DELAY", 0.5))
 
 # from the C driver
@@ -51,7 +51,8 @@ class MCP2221:
     def __init__(self):
         self._hid = hid.device()
         self._hid.open(MCP2221.VID, MCP2221.PID)
-        self._reset()
+        if MCP2221_RESET_DELAY >= 0:
+            self._reset()
         self._gp_config = [0x07] * 4  # "don't care" initial value
         for pin in range(4):
             self.gp_set_mode(pin, self.GP_GPIO)  # set to GPIO mode


### PR DESCRIPTION
I have an MCP2221 that I could not for the life of me get to work with Blinka until I by-hand skipped the `_reset` stage. On my system (Ubuntu 20.04 on kernel 5.8.10), for whatever reason the reset process takes forever, sometimes >15 seconds. But for many of my use cases I don't really need to bother with the reset process anyway since I'm often just plugging it once so that I know it's already been reset.

So this PR adds a convenient way to skip the reset phase: set the `BLINKA_MCP2221_RESET_DELAY` environment variable to any negative number.  If you prefer not to overload envars this way I could also change it to ust a variable like `BLINKA_MCP2221_SKIP_RESET` or something like that instead.