### PR TITLE
If the number of retries is exceeded raise an error

### DIFF
--- a/src/adafruit_blinka/microcontroller/mcp2221/mcp2221.py
+++ b/src/adafruit_blinka/microcontroller/mcp2221/mcp2221.py
@@ -285,6 +285,8 @@ class MCP2221:
                     continue
                 if resp[2] in (RESP_READ_COMPL, RESP_READ_PARTIAL):
                     break
+            else:
+                raise RuntimeError("I2C read error: max retries reached.")
 
             # move data into buffer
             chunk = min(end - start, 60)


### PR DESCRIPTION
This adds a runtime exception in the I2C read call if the number of retries is exceeded. This mimics the write call. Currently the code continues even if the retries are exceeded. I ran into this as an issue when trying the SI7021. The SI7021 NACKs reads when it isn't ready to provide a temperature and the retries can happen so fast that it is never ready in time for a valid value.