### PR TITLE
Do not prematurely stop waiting for an answer from the message queue

### DIFF
--- a/src/adafruit_blinka/microcontroller/bcm283x/pulseio/PulseIn.py
+++ b/src/adafruit_blinka/microcontroller/bcm283x/pulseio/PulseIn.py
@@ -70,26 +70,29 @@ class PulseIn:
         # wait for it to start up
         if DEBUG:
             print("Waiting for startup success message from subprocess")
-        message = self._wait_receive_msg()
+        message = self._wait_receive_msg(timeout=0.25)
         if message[0] != b"!":
             raise RuntimeError("Could not establish message queue with subprocess")
         self._paused = False
 
     # pylint: disable=redefined-builtin
-    def _wait_receive_msg(self, timeout=0.25, type=2):
+    def _wait_receive_msg(self, timeout=0, type=2):
         """Internal helper that will wait for new messages of a given type,
         and throw an exception on timeout"""
-        stamp = time.monotonic()
-        while (time.monotonic() - stamp) < timeout:
-            try:
-                message = self._mq.receive(block=False, type=type)
-                return message
-            except sysv_ipc.BusyError:
-                time.sleep(0.001)  # wait a bit then retry!
-        # uh-oh timed out
-        raise RuntimeError(
-            "Timed out waiting for PulseIn message. Make sure libgpiod is installed."
-        )
+        if timeout > 0:
+            stamp = time.monotonic()
+            while (time.monotonic() - stamp) < timeout:
+                try:
+                    message = self._mq.receive(block=False, type=type)
+                    return message
+                except sysv_ipc.BusyError:
+                    time.sleep(0.001)  # wait a bit then retry!
+            # uh-oh timed out
+            raise RuntimeError(
+                "Timed out waiting for PulseIn message. Make sure libgpiod is installed."
+            )
+        message = self._mq.receive(block=True, type=type)
+        return message
 
     # pylint: enable=redefined-builtin
 


### PR DESCRIPTION
Trying to debug adafruit/Adafruit_CircuitPython_DHT/issues/52 I stumbled across this issue. On high system load, bcm283x/pulseio/PulseIn.py will get itself into trouble due to pure impatience:

When requesting data from libgpiod_pulsein via the message queue, we
always expect an answer. Prematurely stopping to wait for an answer can
only do harm. If we do not read the expected answer from the mq, it will
stay there and be read (falsely) as an answer to the following request.

Example:

* We request a pulse length by sending '^'.
* Due to high system load, libgpiod_pulsein does not send a response in
  time.
* We timeout with a RuntimeError. This is verly likely ignored by the
  calling code since RuntimeErrors are thrown with every invalid
  reading such that the calling code _has to_ ignore these errors.
* We trigger a new sensor reading (pause-clean-resume).
* We request the length of the pulse buffer by sending 'l'.
* We read from the message queue. The response we get now is the
  response to our original '^' request. Let this response be 100.
* We now assume 100 elements in the pulse buffer. This is of course
  wrong and will lead to all sorts of errors.

The only reason to timeout on an expected answer is probably during
initialization when we are not sure if the communication via message
queue has been successfully set up. In all other cases we should just
block and never timeout.