### PR TITLE
Compatibility with generic linux devices

### DIFF
--- a/src/busio.py
+++ b/src/busio.py
@@ -27,16 +27,16 @@ class I2C(Lockable):
     for both MicroPython and Linux.
     """
 
-    def __init__(self, scl, sda, frequency=400000, i2c_addr=None):
-        self.init(scl, sda, frequency, i2c_addr)
+    def __init__(self, scl=None, sda=None, frequency=400000, i2c_device=None):
+        self.init(scl, sda, frequency, i2c_device)
 
-    def init(self, scl, sda, frequency, i2c_addr):
+    def init(self, scl, sda, frequency, i2c_device):
         """Initialization"""
         self.deinit()
-        if i2c_addr:
+        if i2c_device is not None:
             from adafruit_blinka.microcontroller.generic_linux.i2c import I2C as _I2C
 
-            self._i2c = _I2C(i2c_addr, mode=_I2C.MASTER, baudrate=frequency)
+            self._i2c = _I2C(i2c_device, mode=_I2C.MASTER, baudrate=frequency)
             return
         if detector.board.ftdi_ft232h:
             from adafruit_blinka.microcontroller.ft232h.i2c import I2C as _I2C

--- a/src/busio.py
+++ b/src/busio.py
@@ -33,6 +33,11 @@ class I2C(Lockable):
     def init(self, scl, sda, frequency, i2c_addr):
         """Initialization"""
         self.deinit()
+        if i2c_addr:
+            from adafruit_blinka.microcontroller.generic_linux.i2c import I2C as _I2C
+
+            self._i2c = _I2C(i2c_addr, mode=_I2C.MASTER, baudrate=frequency)
+            return
         if detector.board.ftdi_ft232h:
             from adafruit_blinka.microcontroller.ft232h.i2c import I2C as _I2C
 
@@ -56,11 +61,6 @@ class I2C(Lockable):
         if detector.board.any_embedded_linux:
             from adafruit_blinka.microcontroller.generic_linux.i2c import I2C as _I2C
 
-        if detector.board.id == 'GENERIC_LINUX_PC':
-            from adafruit_blinka.microcontroller.generic_linux.i2c import I2C as _I2C
-
-            self._i2c = _I2C(i2c_addr, mode=_I2C.MASTER, baudrate=frequency)
-            return
         else:
             from machine import I2C as _I2C
         from microcontroller.pin import i2cPorts

--- a/src/busio.py
+++ b/src/busio.py
@@ -27,10 +27,10 @@ class I2C(Lockable):
     for both MicroPython and Linux.
     """
 
-    def __init__(self, scl, sda, frequency=400000):
-        self.init(scl, sda, frequency)
+    def __init__(self, scl, sda, frequency=400000, i2c_addr=None):
+        self.init(scl, sda, frequency, i2c_addr)
 
-    def init(self, scl, sda, frequency):
+    def init(self, scl, sda, frequency, i2c_addr):
         """Initialization"""
         self.deinit()
         if detector.board.ftdi_ft232h:
@@ -55,6 +55,12 @@ class I2C(Lockable):
             return
         if detector.board.any_embedded_linux:
             from adafruit_blinka.microcontroller.generic_linux.i2c import I2C as _I2C
+
+        if detector.board.id == 'GENERIC_LINUX_PC':
+            from adafruit_blinka.microcontroller.generic_linux.i2c import I2C as _I2C
+
+            self._i2c = _I2C(i2c_addr, mode=_I2C.MASTER, baudrate=frequency)
+            return
         else:
             from machine import I2C as _I2C
         from microcontroller.pin import i2cPorts


### PR DESCRIPTION
Hello,
I made these changes because i need to use rfid library from pc with i2c-tiniy-usb adapter. I initially based the check on "detector.board.id == 'GENERIC_LINUX_PC'"
But then I preferred to keep better compatibility by checking if the new "i2c_addr" parameter was passed. (so you can use a USB-I2C adapter on the raspberry too)
Regards