### PR TITLE
expose the neopixel_cleanup method in the main module.

### DIFF
--- a/src/neopixel_write.py
+++ b/src/neopixel_write.py
@@ -23,3 +23,8 @@ else:
 def neopixel_write(gpio, buf):
     """Write buf out on the given DigitalInOut."""
     return _neopixel.neopixel_write(gpio, buf)
+
+
+def neopixel_cleanup():
+    """Cleanup and destroy the neopixel resources"""
+    return _neopixel.neopixel_cleanup()


### PR DESCRIPTION
Simple change to expose the cleanup method which is bcm283x module in the main module. This method is called atexit of the process, but there are some scenarios where you might want to clean it up before a process exists. For example, you could be changing the length of the string.