### PR TITLE
Update pin.py

### DIFF
--- a/src/adafruit_blinka/microcontroller/bcm283x/pin.py
+++ b/src/adafruit_blinka/microcontroller/bcm283x/pin.py
@@ -148,7 +148,7 @@ spiPorts = (
 uartPorts = ((1, TXD, RXD),)
 
 i2cPorts = (
-    (3, SCL, SDA),
+    # (3, SCL, SDA),  issue: this bus get selected if another I2C bus is enabled
     (1, SCL, SDA),
     (0, D1, D0),  # both pi 1 and pi 2 i2c ports!
 )


### PR DESCRIPTION
I ran into an issue when I created an additional I2C bus on my raspbery pi zero with num_id=3 by adding an overlay in /boot/config.txt like this :
dtoverlay=i2c-gpio,bus=3,i2c_gpio_delay_us=1,i2c_gpio_sda=17,i2c_gpio_scl=27