### PR TITLE
Change default I2C clock frequency

### DIFF
--- a/src/busio.py
+++ b/src/busio.py
@@ -27,7 +27,7 @@ class I2C(Lockable):
     for both MicroPython and Linux.
     """
 
-    def __init__(self, scl, sda, frequency=400000):
+    def __init__(self, scl, sda, frequency=100000):
         self.init(scl, sda, frequency)
 
     def init(self, scl, sda, frequency):


### PR DESCRIPTION
Minor changed suggested in #391 , but probably not an actual fix for that specific issue. Current default is 400kHz, but 100kHz is generally accepted as the more "standard" clock speed. So this change is simply to bring in line with that.
