### PR TITLE
Privitize `i2c_configure` in MCP2221 class

### DIFF
--- a/src/adafruit_blinka/microcontroller/mcp2221/i2c.py
+++ b/src/adafruit_blinka/microcontroller/mcp2221/i2c.py
@@ -7,7 +7,7 @@ class I2C:
 
     def __init__(self, *, frequency=100000):
         self._mcp2221 = mcp2221
-        self._mcp2221.i2c_configure(frequency)
+        self._mcp2221._i2c_configure(frequency)
 
     def scan(self):
         """Perform an I2C Device Scan"""

--- a/src/adafruit_blinka/microcontroller/mcp2221/mcp2221.py
+++ b/src/adafruit_blinka/microcontroller/mcp2221/mcp2221.py
@@ -296,7 +296,7 @@ class MCP2221:
 
     # pylint: enable=too-many-arguments
 
-    def i2c_configure(self, baudrate=100000):
+    def _i2c_configure(self, baudrate=100000):
         """Configure I2C"""
         self._hid_xfer(
             bytes(


### PR DESCRIPTION
Mainly just a cosmetic change to deal with #391 . As is, this function does not seem to work reliably when called after the initial setup. But it works OK as currently used from constructor. So for now, just adding `_` to indicate it's for internal use only. And it was already buried in the MCP class, so it's internally internal? Anywho, nothing broken.

I2C scan with a VEML6075 attached:
```python
~$ python3
Python 3.6.9 (default, Oct  8 2020, 12:12:24) 
[GCC 8.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import board
>>> i2c = board.I2C()
>>> i2c.scan()
[16]
>>> 
```

![Screenshot from 2021-01-14 16-53-03](https://user-images.githubusercontent.com/8755041/104666743-7944ea80-5689-11eb-9255-b74ceab5e5a3.png)
