### PR TITLE
Add support for LubanCat i.MX6ULL board

### DIFF
--- a/examples/analog_in.py
+++ b/examples/analog_in.py
@@ -1,11 +1,14 @@
+"""Analog in demo"""
 import time
 import board
 from analogio import AnalogIn
 
 analog_in = AnalogIn(board.A1)
 
+
 def get_voltage(pin):
     return (pin.value * 3.3) / 4096
+
 
 while True:
     print((get_voltage(analog_in),))

--- a/examples/analog_in.py
+++ b/examples/analog_in.py
@@ -1,0 +1,12 @@
+import time
+import board
+from analogio import AnalogIn
+
+analog_in = AnalogIn(board.A1)
+
+def get_voltage(pin):
+    return (pin.value * 3.3) / 4096
+
+while True:
+    print((get_voltage(analog_in),))
+    time.sleep(0.1)

--- a/src/adafruit_blinka/board/lubancat/__init__.py
+++ b/src/adafruit_blinka/board/lubancat/__init__.py
@@ -1,0 +1,1 @@
+"""Boards definition from LubanCat"""

--- a/src/adafruit_blinka/board/lubancat/lubancat_imx6ull.py
+++ b/src/adafruit_blinka/board/lubancat/lubancat_imx6ull.py
@@ -1,0 +1,51 @@
+"""Pin definitions for the LubanCat IMX6ULL."""
+
+from adafruit_blinka.microcontroller.nxp_imx6ull import pin
+
+# Pro board pin header CN4 named GPIO_PAx, pin header CN5 named GPIO_PBx
+# Mini board pin header CN3 named GPIO_PCx, pin header CN4 named GPIO_PDx
+
+# Board pin name [= alias] = RPI name [= alias] = pin name
+GPIO_PC3 = I2C2_SDA = D2 = SDA = pin.I2C2_SDA
+GPIO_PC5 = I2C2_SCL = D3 = SCL = pin.I2C2_SCL
+
+GPIO_PC7 = D4 = pin.GPIO27
+GPIO_PC8 = D14 = TXD = pin.UART3_TXD
+GPIO_PC10 = D15 = RXD = pin.UART3_RXD
+GPIO_PC11 = ADC_IN3 = A3 = D17 = pin.GPIO3
+GPIO_PC12 = D18 = pin.GPIO112
+GPIO_PC13 = ADC_IN2 = A2 = D27 = pin.GPIO2
+GPIO_PC15 = ADC_IN0 = A0 = D22 = pin.GPIO0
+GPIO_PC16 = D23 = pin.GPIO119
+GPIO_PC18 = D24 = pin.GPIO114
+
+GPIO_PC19 = ECSPI3_MOSI = D10 = MOSI = pin.ECSPI3_MOSI
+GPIO_PC21 = ECSPI3_MISO = D9 = MISO = pin.ECSPI3_MISO
+GPIO_PC22 = D25 = pin.GPIO27
+GPIO_PC23 = ECSPI3_SCLK = D11 = SCLK = SCK = pin.ECSPI3_SCLK
+GPIO_PC24 = ECSPI3_SS0 = D8 = SS0 = pin.ECSPI3_SS0
+GPIO_PC26 = ECSPI3_SS1 = D7 = SS1 = pin.ECSPI3_SS1
+
+GPIO_PC27 = I2C3_SDA = D0 = pin.I2C3_SDA
+GPIO_PC28 = I2C3_SCL = D1 = pin.I2C3_SCL
+
+GPIO_PC29 = D5 = pin.GPIO117
+GPIO_PC31 = D6 = pin.GPIO118
+
+GPIO_PC32 = LED_D6 = D12 = pin.GPIO115
+GPIO_PC33 = LED_D5 = D13 = pin.GPIO116
+
+# Board pwm channel = RPI PWM Channel = pin name
+PWM_C7 = PWM1 = pin.GPIO115
+PWM_C8 = PWM2 = pin.GPIO116
+
+GPIO_PC35 = D19 = pin.GPIO121
+GPIO_PC36 = D16 = pin.GPIO120
+GPIO_PC37 = D26 = pin.GPIO26
+GPIO_PC38 = D20 = pin.GPIO123
+GPIO_PC40 = D21 = pin.GPIO124
+
+# Mini header CN4
+GPIO_PD9 = ADC_IN1 = A1 = pin.GPIO1
+GPIO_PD4 = LED_D4 = PWM_C3 = pin.GPIO4
+GPIO_PD17 = BUTTON2 = pin.GPIO129

--- a/src/adafruit_blinka/microcontroller/nxp_imx6ull/pin.py
+++ b/src/adafruit_blinka/microcontroller/nxp_imx6ull/pin.py
@@ -40,13 +40,13 @@ GPIO124 = Pin((3, 28))  # GPIO4_IO28
 
 GPIO129 = Pin((4, 1))  # GPIO5_IO1
 
-i2cPorts = ( 
+i2cPorts = (
     (1, I2C2_SCL, I2C2_SDA),
     (2, I2C3_SCL, I2C3_SDA),
 )
 
 # ordered as spiId, sckId, mosiId, misoId
-spiPorts = ( (2, ECSPI3_SCLK, ECSPI3_MOSI, ECSPI3_MISO), )
+spiPorts = ((2, ECSPI3_SCLK, ECSPI3_MOSI, ECSPI3_MISO),)
 
 # UART3_TXD/RXD on /dev/ttymxc2
 uartPorts = ((2, UART3_TXD, UART3_RXD),)

--- a/src/adafruit_blinka/microcontroller/nxp_imx6ull/pin.py
+++ b/src/adafruit_blinka/microcontroller/nxp_imx6ull/pin.py
@@ -1,0 +1,67 @@
+"""NXP IMX6ULL pin names"""
+from adafruit_blinka.microcontroller.generic_linux.libgpiod_pin import Pin
+
+# GPIO num = reconment function = Pin((chip, line))
+GPIO31 = I2C2_SDA = Pin((0, 31))  # GPIO1_IO31
+GPIO30 = I2C2_SCL = Pin((0, 30))  # GPIO1_IO30
+
+GPIO29 = I2C3_SDA = Pin((0, 29))  # GPIO1_IO29
+GPIO28 = I2C3_SCL = Pin((0, 28))  # GPIO1_IO28
+
+GPIO24 = UART3_TXD = Pin((0, 24))  # GPIO1_IO24
+GPIO25 = UART3_RXD = Pin((0, 25))  # GPIO1_IO25
+
+GPIO22 = ECSPI3_MOSI = Pin((0, 22))  # GPIO1_IO22
+GPIO23 = ECSPI3_MISO = Pin((0, 23))  # GPIO1_IO23
+GPIO21 = ECSPI3_SCLK = Pin((0, 21))  # GPIO1_IO21
+GPIO20 = ECSPI3_SS0 = Pin((0, 20))  # GPIO1_IO20
+GPIO18 = ECSPI3_SS1 = Pin((0, 18))  # GPIO1_IO18
+
+GPIO0 = ADC_IN0 = Pin((0, 0))  # GPIO1_IO0
+GPIO1 = ADC_IN1 = Pin((0, 1))  # GPIO1_IO2
+GPIO2 = ADC_IN2 = Pin((0, 2))  # GPIO1_IO2
+GPIO3 = ADC_IN3 = Pin((0, 3))  # GPIO1_IO3
+GPIO4 = PWM_C3 = Pin((0, 4))  # GPIO1_IO4
+GPIO26 = Pin((0, 26))  # GPIO1_IO26
+GPIO27 = Pin((0, 27))  # GPIO1_IO27
+
+GPIO113 = Pin((3, 17))  # GPIO4_IO17
+GPIO114 = Pin((3, 18))  # GPIO4_IO18
+GPIO115 = PWM_C7 = Pin((3, 19))  # GPIO4_IO19
+GPIO116 = PWM_C8 = Pin((3, 20))  # GPIO4_IO20
+GPIO117 = Pin((3, 21))  # GPIO4_IO21
+GPIO118 = Pin((3, 22))  # GPIO4_IO22
+GPIO119 = Pin((3, 23))  # GPIO4_IO23
+GPIO120 = Pin((3, 24))  # GPIO4_IO24
+GPIO121 = Pin((3, 25))  # GPIO4_IO25
+GPIO112 = Pin((3, 26))  # GPIO4_IO26
+GPIO123 = Pin((3, 27))  # GPIO4_IO27
+GPIO124 = Pin((3, 28))  # GPIO4_IO28
+
+GPIO129 = Pin((4, 1))  # GPIO5_IO1
+
+i2cPorts = ( 
+    (1, I2C2_SCL, I2C2_SDA),
+    (2, I2C3_SCL, I2C3_SDA),
+)
+
+# ordered as spiId, sckId, mosiId, misoId
+spiPorts = ( (2, ECSPI3_SCLK, ECSPI3_MOSI, ECSPI3_MISO), )
+
+# UART3_TXD/RXD on /dev/ttymxc2
+uartPorts = ((2, UART3_TXD, UART3_RXD),)
+
+# SysFS pwm outputs, pwm channel and pin in first tuple
+pwmOuts = (
+    ((2, 0), PWM_C3),
+    ((6, 0), PWM_C7),
+    ((7, 0), PWM_C8),
+)
+
+# SysFS analog inputs, Ordered as analog analogInId, device, and channel
+analogIns = (
+    (ADC_IN0, 0, 0),
+    (ADC_IN1, 0, 1),
+    (ADC_IN2, 0, 2),
+    (ADC_IN3, 0, 3),
+)

--- a/src/analogio.py
+++ b/src/analogio.py
@@ -21,6 +21,8 @@ elif detector.board.greatfet_one:
     from adafruit_blinka.microcontroller.nxp_lpc4330.analogio import AnalogOut
 elif detector.chip.RK3308:
     from adafruit_blinka.microcontroller.generic_linux.sysfs_analogin import AnalogIn
+elif detector.chip.IMX6ULL:
+    from adafruit_blinka.microcontroller.generic_linux.sysfs_analogin import AnalogIn
 elif "sphinx" in sys.modules:
     pass
 else:

--- a/src/board.py
+++ b/src/board.py
@@ -183,6 +183,9 @@ elif board_id == ap_board.UDOO_X86:
 elif board_id == ap_board.STM32MP157C_DK2:
     from adafruit_blinka.board.stm32.stm32mp157c_dk2 import *
 
+elif board_id == ap_board.LUBANCAT_IMX6ULL:
+    from adafruit_blinka.board.lubancat.lubancat_imx6ull import *
+
 elif "sphinx" in sys.modules:
     pass
 

--- a/src/busio.py
+++ b/src/busio.py
@@ -269,6 +269,9 @@ class SPI(Lockable):
         elif board_id == ap_board.ONION_OMEGA2:
             from adafruit_blinka.microcontroller.mips24kec.pin import Pin
             from adafruit_blinka.microcontroller.generic_linux.spi import SPI as _SPI
+        elif detector.board.any_lubancat and detector.chip.id == ap_chip.IMX6ULL:
+            from adafruit_blinka.microcontroller.nxp_imx6ull.pin import Pin
+            from adafruit_blinka.microcontroller.generic_linux.spi import SPI as _SPI
         else:
             from machine import SPI as _SPI
             from machine import Pin

--- a/src/digitalio.py
+++ b/src/digitalio.py
@@ -37,6 +37,8 @@ elif detector.chip.APQ8016:
     from adafruit_blinka.microcontroller.snapdragon.apq8016.pin import Pin
 elif detector.chip.IMX8MX:
     from adafruit_blinka.microcontroller.nxp_imx8m.pin import Pin
+elif detector.chip.IMX6ULL:
+    from adafruit_blinka.microcontroller.nxp_imx6ull.pin import Pin
 elif detector.chip.HFU540:
     from adafruit_blinka.microcontroller.hfu540.pin import Pin
 elif detector.chip.A64:

--- a/src/microcontroller/__init__.py
+++ b/src/microcontroller/__init__.py
@@ -68,6 +68,8 @@ elif chip_id == ap_chip.RK3308:
     from adafruit_blinka.microcontroller.rockchip.rk3308.pin import *
 elif chip_id == ap_chip.IMX8MX:
     from adafruit_blinka.microcontroller.nxp_imx8m import *
+elif chip_id == ap_chip.IMX6ULL:
+    from adafruit_blinka.microcontroller.nxp_imx6ull import *
 elif chip_id == ap_chip.HFU540:
     from adafruit_blinka.microcontroller.hfu540.pin import *
 elif chip_id == ap_chip.BINHO:

--- a/src/microcontroller/pin.py
+++ b/src/microcontroller/pin.py
@@ -36,6 +36,8 @@ elif chip_id == ap_chip.APQ8016:
     from adafruit_blinka.microcontroller.snapdragon.apq8016.pin import *
 elif chip_id == ap_chip.IMX8MX:
     from adafruit_blinka.microcontroller.nxp_imx8m.pin import *
+elif chip_id == ap_chip.IMX6ULL:
+    from adafruit_blinka.microcontroller.nxp_imx6ull.pin import *
 elif chip_id == ap_chip.HFU540:
     from adafruit_blinka.microcontroller.hfu540.pin import *
 elif chip_id == ap_chip.FT232H:

--- a/src/pulseio.py
+++ b/src/pulseio.py
@@ -28,6 +28,8 @@ elif detector.board.binho_nova:
     from adafruit_blinka.microcontroller.nova.pwmout import PWMOut
 elif detector.board.greatfet_one:
     from adafruit_blinka.microcontroller.nxp_lpc4330.pwmout import PWMOut
+elif detector.board.any_lubancat:
+    from adafruit_blinka.microcontroller.generic_linux.sysfs_pwmout import PWMOut
 elif "sphinx" in sys.modules:
     pass
 else:


### PR DESCRIPTION
This is the pins and board support for LubanCat i.MX6ULL.
 Its contains ditital IO, busio, pulseio and analog in.

And I added an analog in example to make testing easier.

I‘ve added platform detect for LubanCat: https://github.com/adafruit/Adafruit_Python_PlatformDetect/pull/130

