### PR TITLE
Fix SPI.readinto with write_data=NONZERO

### DIFF
--- a/src/adafruit_blinka/microcontroller/ft232h/spi.py
+++ b/src/adafruit_blinka/microcontroller/ft232h/spi.py
@@ -67,7 +67,10 @@ class SPI:
     def readinto(self, buf, start=0, end=None, write_value=0):
         """Read data from SPI and into the buffer"""
         end = end if end else len(buf)
-        result = self._port.read(end - start)
+        buffer_out = [write_value] * (end-start)
+        result = self._port.exchange(
+            buffer_out, end - start, duplex=True
+        )
         for i, b in enumerate(result):
             buf[start + i] = b
 

--- a/src/adafruit_blinka/microcontroller/ft232h/spi.py
+++ b/src/adafruit_blinka/microcontroller/ft232h/spi.py
@@ -67,10 +67,8 @@ class SPI:
     def readinto(self, buf, start=0, end=None, write_value=0):
         """Read data from SPI and into the buffer"""
         end = end if end else len(buf)
-        buffer_out = [write_value] * (end-start)
-        result = self._port.exchange(
-            buffer_out, end - start, duplex=True
-        )
+        buffer_out = [write_value] * (end - start)
+        result = self._port.exchange(buffer_out, end - start, duplex=True)
         for i, b in enumerate(result):
             buf[start + i] = b
 

--- a/src/adafruit_blinka/microcontroller/nxp_lpc4330/spi.py
+++ b/src/adafruit_blinka/microcontroller/nxp_lpc4330/spi.py
@@ -93,7 +93,7 @@ class SPI:
     def readinto(self, buf, start=0, end=None, write_value=0):
         """Read data from SPI and into the buffer"""
         end = end if end else len(buf)
-        result = self._transmit([write_value] * (end-start), end - start)
+        result = self._transmit([write_value] * (end - start), end - start)
         for i, b in enumerate(result):
             buf[start + i] = b
 

--- a/src/adafruit_blinka/microcontroller/nxp_lpc4330/spi.py
+++ b/src/adafruit_blinka/microcontroller/nxp_lpc4330/spi.py
@@ -93,7 +93,7 @@ class SPI:
     def readinto(self, buf, start=0, end=None, write_value=0):
         """Read data from SPI and into the buffer"""
         end = end if end else len(buf)
-        result = self._transmit([], end - start)
+        result = self._transmit([write_value] * (end-start), end - start)
         for i, b in enumerate(result):
             buf[start + i] = b
 


### PR DESCRIPTION
This is a tested fix for ft232h and a speculative fix for nxp_lpc4330. I used the Adafruit FT232H breakout (current version, w/USB-C and Stemma connector) and the Adafruit "microSD SPI or SDIO" breakout for my most recent round of testing. The connections were D0/D1/D2 for the SPI signals and D4 for the Chip Select signal. I used Linux as my host computer.

@gerd1986 please let us know whether this change allows you to access the SD card with the FT232H interface.

I tested with the following script:
```python
import board
import digitalio
import adafruit_sdcard

cs = digitalio.DigitalInOut(board.D4)
bus = board.SPI()
card = adafruit_sdcard.SDCard(bus, cs)
print("capacity (in 512-byte blocks", card.count())
buf = bytearray([0]) * 512
card.readblocks(0, buf)
print("content of first block")
for i in range(0, 512, 16):
    print("%3d" % i, " ".join("%02X" % b for b in buf[i:i+16]))
```

Typical output:
```
capacity (in 512-byte blocks 15523840
content of first block
  0 FA B8 00 10 8E D0 BC 00 B0 B8 00 00 8E D8 8E C0
 16 FB BE 00 7C BF 00 06 B9 00 02 F3 A4 EA 21 06 00
 32 00 BE BE 07 38 04 75 0B 83 C6 10 81 FE FE 07 75
 48 F3 EB 16 B4 02 B0 01 BB 00 7C B2 80 8A 74 01 8B
 64 4C 02 CD 13 EA 00 7C 00 00 EB FE 00 00 00 00 00
 80 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
 96 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
112 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
128 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
144 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
160 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
176 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
192 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
208 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
224 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
240 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
256 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
272 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
288 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
304 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
320 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
336 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
352 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
368 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
384 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
400 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
416 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
432 00 00 00 00 00 00 00 00 92 EB 7F FC 00 00 00 00
448 01 40 0C 03 E0 FF 00 20 00 00 00 00 08 00 00 03
464 E0 FF 83 3F E0 FF 00 20 08 00 00 C0 E4 00 00 00
480 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
496 00 00 00 00 00 00 00 00 00 00 00 00 00 00 55 AA
```