### PR TITLE
update minimum version of Adafruit-PlatformDetect

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Adafruit-PlatformDetect>=2.18.1
+Adafruit-PlatformDetect>=2.27.0
 Adafruit-PureIO>=1.1.7
 Jetson.GPIO; platform_machine=='aarch64'
 RPi.GPIO; platform_machine=='armv7l' or platform_machine=='armv6l'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Adafruit-PlatformDetect>=2.27.0
+Adafruit-PlatformDetect>=2.28.0
 Adafruit-PureIO>=1.1.7
 Jetson.GPIO; platform_machine=='aarch64'
 RPi.GPIO; platform_machine=='armv7l' or platform_machine=='armv6l'


### PR DESCRIPTION
Needed since 8273fc6, otherwise you will get:

```
AttributeError: module 'adafruit_platformdetect.constants.chips' has no attribute 'DRA74X'
```