### PR TITLE
adds pin PG11 i2c, spi, serialUART support for nanoPi Duo2

### DIFF
--- a/src/adafruit_blinka/board/nanopi/duo2.py
+++ b/src/adafruit_blinka/board/nanopi/duo2.py
@@ -1,0 +1,23 @@
+"""Pin definitions for the NanoPi Duo2."""
+# Enable I2C0, UART1, and SPI by adding the following lines to /boot/armbianEnv.txt
+#    overlays=usbhost2 usbhost3 spi-spidev uart1 i2c0
+#    param_spidev_spi_bus=0
+
+from adafruit_blinka.microcontroller.allwinner.h3 import pin
+
+# Left GPIO
+PG11 = pin.PG11
+
+# I2C
+SDA = pin.PA12
+SCL = pin.PA11
+
+# SPI
+SCLK = pin.PA14
+MOSI = pin.PA15
+MISO = pin.PA16
+CE0 = pin.PA13
+
+# Serial UART
+UART1_TX = pin.PG6
+UART1_RX = pin.PG7

--- a/src/board.py
+++ b/src/board.py
@@ -197,6 +197,9 @@ elif board_id == ap_board.LUBANCAT_IMX6ULL:
 elif board_id == ap_board.NANOPI_NEO_AIR:
     from adafruit_blinka.board.nanopi.neoair import *
 
+elif board_id == ap_board.NANOPI_DUO2:
+    from adafruit_blinka.board.nanopi.duo2 import *
+
 elif "sphinx" in sys.modules:
     pass
 


### PR DESCRIPTION
This adds nanoPi Duo2 to usable boards.