### PR TITLE
Remove I2C bus 3 from BCM283x

### DIFF
--- a/src/adafruit_blinka/microcontroller/bcm283x/pin.py
+++ b/src/adafruit_blinka/microcontroller/bcm283x/pin.py
@@ -147,6 +147,9 @@ spiPorts = (
 # ordered as uartId, txId, rxId
 uartPorts = ((1, TXD, RXD),)
 
+# These are the known hardware I2C ports / pins.
+# For software I2C ports created with the i2c-gpio overlay, see:
+#     https://github.com/adafruit/Adafruit_Python_Extended_Bus
 i2cPorts = (
     (1, SCL, SDA),
     (0, D1, D0),  # both pi 1 and pi 2 i2c ports!

--- a/src/adafruit_blinka/microcontroller/bcm283x/pin.py
+++ b/src/adafruit_blinka/microcontroller/bcm283x/pin.py
@@ -148,7 +148,6 @@ spiPorts = (
 uartPorts = ((1, TXD, RXD),)
 
 i2cPorts = (
-    (3, SCL, SDA),
     (1, SCL, SDA),
     (0, D1, D0),  # both pi 1 and pi 2 i2c ports!
 )


### PR DESCRIPTION
For #410.

Removes an entry that allowed use of a very specifically configured `i2c-gpio` port which could then mask the existing default hardware port, for cases where both were trying to be used.
