### PR TITLE
Fix recent RaspiOS not installing RPi.GPIO

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ if os.path.exists("/proc/device-tree/compatible"):
         or b"brcm,bcm2836" in compat
         or b"brcm,bcm2837" in compat
         or b"brcm,bcm2838" in compat
+        or b"brcm,bcm2711" in compat
     ):
         board_reqs = ["RPi.GPIO", "rpi_ws281x>=4.0.0", "sysv_ipc>=1.1.0"]
 


### PR DESCRIPTION
A recent release of Raspberry Pi OS now has `raspberrypi,4-model-bbrcm,bcm2711` in `/proc/device-tree/compatible`.