### PR TITLE
Fix #423 FT232H Pin returns NotImplementedError

### DIFF
--- a/src/adafruit_blinka/microcontroller/ft232h/pin.py
+++ b/src/adafruit_blinka/microcontroller/ft232h/pin.py
@@ -8,6 +8,9 @@ class Pin:
     OUT = 1
     LOW = 0
     HIGH = 1
+    PULL_NONE = 0
+    PULL_UP =  1
+    PULL_DOWN = 2
 
     ft232h_gpio = None
 
@@ -36,7 +39,7 @@ class Pin:
             raise RuntimeError("Can not init a None type pin.")
         # FT232H does't have configurable internal pulls?
         if pull:
-            raise ValueError("Internal pull up/down not currently supported.")
+            raise NotImplementedError("Internal pull up/down not currently supported.")
         pin_mask = Pin.ft232h_gpio.pins | 1 << self.id
         current = Pin.ft232h_gpio.direction
         if mode == self.OUT:

--- a/src/adafruit_blinka/microcontroller/ft232h/pin.py
+++ b/src/adafruit_blinka/microcontroller/ft232h/pin.py
@@ -9,7 +9,7 @@ class Pin:
     LOW = 0
     HIGH = 1
     PULL_NONE = 0
-    PULL_UP =  1
+    PULL_UP = 1
     PULL_DOWN = 2
 
     ft232h_gpio = None
@@ -39,7 +39,8 @@ class Pin:
             raise RuntimeError("Can not init a None type pin.")
         # FT232H does't have configurable internal pulls?
         if pull:
-            raise NotImplementedError("Internal pull up/down not currently supported.")
+            raise NotImplementedError(
+                "Internal pull up/down not currently supported.")
         pin_mask = Pin.ft232h_gpio.pins | 1 << self.id
         current = Pin.ft232h_gpio.direction
         if mode == self.OUT:

--- a/src/adafruit_blinka/microcontroller/ft232h/pin.py
+++ b/src/adafruit_blinka/microcontroller/ft232h/pin.py
@@ -39,8 +39,7 @@ class Pin:
             raise RuntimeError("Can not init a None type pin.")
         # FT232H does't have configurable internal pulls?
         if pull:
-            raise NotImplementedError(
-                "Internal pull up/down not currently supported.")
+            raise NotImplementedError("Internal pull up/down not currently supported.")
         pin_mask = Pin.ft232h_gpio.pins | 1 << self.id
         current = Pin.ft232h_gpio.direction
         if mode == self.OUT:


### PR DESCRIPTION
#423 
Class Pin of FT232H returns NotImplementedError if pull is not None, now.
Constants PULL_NONE, PULL_UP and PULL_DOWN are defined, now.