### PR TITLE
add microcontroller.delay_us()

### DIFF
--- a/src/microcontroller/__init__.py
+++ b/src/microcontroller/__init__.py
@@ -1,8 +1,15 @@
 """Microcontroller pins"""
 
+import time
+
 from adafruit_platformdetect.constants import chips as ap_chip
 from adafruit_blinka import Enum
 from adafruit_blinka.agnostic import board_id, chip_id
+
+
+def delay_us(delay):
+    """Sleep for delay usecs."""
+    time.sleep(delay / 1e6)
 
 
 class Pin(Enum):


### PR DESCRIPTION
I wrote a [CircuitPython library](https://github.com/dhalbert/CircuitPython_LCD) a long time ago that uses `microcontroller.delay_us()`. Someone wanted to use it on an RPi, and could not use it without modification because `microcontroller.delay_us()` does not exist in Blinka. This adds it, just calling `time.sleep()` to simulate it.

I can't use `time.sleep()` in the original library because it is only accurate to the nearest millisecond. Values smaller than a millisecond are rounded, so, for instance a few hundred microseconds is no delay at all.