### PR TITLE
Add support for ftdi URLs in the BLINKA_FT232H variable.

### DIFF
--- a/src/adafruit_blinka/microcontroller/ft232h/i2c.py
+++ b/src/adafruit_blinka/microcontroller/ft232h/i2c.py
@@ -1,6 +1,6 @@
 """I2C Class for FT232H"""
 from adafruit_blinka.microcontroller.ft232h.pin import Pin
-
+from adafruit_blinka.microcontroller.ft232h.url import get_ftdi_url
 
 class I2C:
     """Custom I2C Class for FT232H"""
@@ -13,7 +13,7 @@ class I2C:
         # pylint: enable=import-outside-toplevel
 
         self._i2c = I2cController()
-        self._i2c.configure("ftdi://ftdi:ft232h/1", frequency=frequency)
+        self._i2c.configure(get_ftdi_url(), frequency=frequency)
         Pin.ft232h_gpio = self._i2c.get_gpio()
 
     def scan(self):

--- a/src/adafruit_blinka/microcontroller/ft232h/i2c.py
+++ b/src/adafruit_blinka/microcontroller/ft232h/i2c.py
@@ -2,6 +2,7 @@
 from adafruit_blinka.microcontroller.ft232h.pin import Pin
 from adafruit_blinka.microcontroller.ft232h.url import get_ftdi_url
 
+
 class I2C:
     """Custom I2C Class for FT232H"""
 

--- a/src/adafruit_blinka/microcontroller/ft232h/pin.py
+++ b/src/adafruit_blinka/microcontroller/ft232h/pin.py
@@ -2,6 +2,7 @@
 
 from adafruit_blinka.microcontroller.ft232h.url import get_ftdi_url
 
+
 class Pin:
     """A basic Pin class for use with FT232H."""
 

--- a/src/adafruit_blinka/microcontroller/ft232h/pin.py
+++ b/src/adafruit_blinka/microcontroller/ft232h/pin.py
@@ -1,5 +1,6 @@
 """FT232H pin names"""
 
+from adafruit_blinka.microcontroller.ft232h.url import get_ftdi_url
 
 class Pin:
     """A basic Pin class for use with FT232H."""
@@ -24,7 +25,7 @@ class Pin:
             # pylint: enable=import-outside-toplevel
 
             i2c = I2cController()
-            i2c.configure("ftdi://ftdi:ft232h/1")
+            i2c.configure(get_ftdi_url())
             Pin.ft232h_gpio = i2c.get_gpio()
         # check if pin is valid
         if pin_id:

--- a/src/adafruit_blinka/microcontroller/ft232h/spi.py
+++ b/src/adafruit_blinka/microcontroller/ft232h/spi.py
@@ -1,5 +1,6 @@
 """SPI Class for FT232H"""
 from adafruit_blinka.microcontroller.ft232h.pin import Pin
+from adafruit_blinka.microcontroller.ft232h.url import get_ftdi_url
 
 # pylint: disable=protected-access
 class SPI:
@@ -14,7 +15,7 @@ class SPI:
         # pylint: enable=import-outside-toplevel
 
         self._spi = SpiController(cs_count=1)
-        self._spi.configure("ftdi://ftdi:ft232h/1")
+        self._spi.configure(get_ftdi_url())
         self._port = self._spi.get_port(0)
         self._port.set_frequency(100000)
         self._port._cpol = 0

--- a/src/adafruit_blinka/microcontroller/ft232h/url.py
+++ b/src/adafruit_blinka/microcontroller/ft232h/url.py
@@ -2,10 +2,11 @@
 
 import os
 
+
 def get_ftdi_url():
     """
     Return the FTDI url to use. If BLINKA_FT232H starts with ftdi:, returns
-    that. Otherwise, returns a default value.  
+    that. Otherwise, returns a default value.
     """
 
     url = os.environ.get("BLINKA_FT232H", "1")

--- a/src/adafruit_blinka/microcontroller/ft232h/url.py
+++ b/src/adafruit_blinka/microcontroller/ft232h/url.py
@@ -13,5 +13,5 @@ def get_ftdi_url():
 
     if url.startswith("ftdi:"):
         return url
-    else:
-        return "ftdi://ftdi:ft232h/1"
+
+    return "ftdi://ftdi:ft232h/1"

--- a/src/adafruit_blinka/microcontroller/ft232h/url.py
+++ b/src/adafruit_blinka/microcontroller/ft232h/url.py
@@ -1,0 +1,16 @@
+"""Support for getting the URL from the BLINKA_FT232H variable."""
+
+import os
+
+def get_ftdi_url():
+    """
+    Return the FTDI url to use. If BLINKA_FT232H starts with ftdi:, returns
+    that. Otherwise, returns a default value.  
+    """
+
+    url = os.environ.get("BLINKA_FT232H", "1")
+
+    if url.startswith("ftdi:"):
+        return url
+    else:
+        return "ftdi://ftdi:ft232h/1"


### PR DESCRIPTION
This allows the an FTDI URL, like ftdi://ftdi:232h:W00001/1
to be given in the BLINKA_FT232H. If it's used, then that
board is the one that is opened. If the value of the variable
is not an FTDI url, then the default is used.

This makes it possible for multiple processes on the same
computer to talk to different FTDI boards. While talking
to multiple boards from a single process might be possible,
that's outside of the scope of this commit.
