### PR TITLE
Added internal I2C bus for the CM4

### DIFF
--- a/src/adafruit_blinka/microcontroller/bcm283x/pin.py
+++ b/src/adafruit_blinka/microcontroller/bcm283x/pin.py
@@ -153,5 +153,5 @@ uartPorts = ((1, TXD, RXD),)
 i2cPorts = (
     (1, SCL, SDA),
     (0, D1, D0),  # both pi 1 and pi 2 i2c ports!
-    (10, D45, D44), # internal i2c bus for the CM4
+    (10, D45, D44),  # internal i2c bus for the CM4
 )

--- a/src/adafruit_blinka/microcontroller/bcm283x/pin.py
+++ b/src/adafruit_blinka/microcontroller/bcm283x/pin.py
@@ -153,4 +153,5 @@ uartPorts = ((1, TXD, RXD),)
 i2cPorts = (
     (1, SCL, SDA),
     (0, D1, D0),  # both pi 1 and pi 2 i2c ports!
+    (10, D45, D44), # internal i2c bus for the CM4
 )


### PR DESCRIPTION
Added I2C bus 10 definition for the Raspberry Pi CM4.
I tested the change on my own CM4 on a custom carrier board and a SSD1306 display and it works fine.

This PR was inspired by this one:
https://github.com/adafruit/Adafruit_Blinka/pull/83

The pins for the I2C bus on the CM4 are described in its datasheet, but the subject is also discussed here:
https://www.raspberrypi.org/forums/viewtopic.php?t=296162

This is my first contribution to an open source project, apologies if I omitted something!