### PR TITLE
Add support for the orignal BeagleBone #439

### DIFF
--- a/src/board.py
+++ b/src/board.py
@@ -56,6 +56,9 @@ elif detector.board.RASPBERRY_PI_B_REV1:
 elif detector.board.RASPBERRY_PI_A or detector.board.RASPBERRY_PI_B_REV2:
     from adafruit_blinka.board.raspberrypi.raspi_1b_rev2 import *
 
+elif board_id == ap_board.BEAGLEBONE:
+    from adafruit_blinka.board.beagleboard.beaglebone_black import *
+
 elif board_id == ap_board.BEAGLEBONE_BLACK:
     from adafruit_blinka.board.beagleboard.beaglebone_black import *
 


### PR DESCRIPTION
The original BeagleBone is same SoC (AM3358) as Black and Green and similar layout in terms of the cape headers.  It should just work once the EEPROM ID for original BeagleBone models is added this conditional logic.  Refer to issue #439