### PR TITLE
Update pico_u2if.py

### DIFF
--- a/src/adafruit_blinka/microcontroller/pico_u2if/pico_u2if.py
+++ b/src/adafruit_blinka/microcontroller/pico_u2if/pico_u2if.py
@@ -322,7 +322,7 @@ class Pico_u2if:
             remain_bytes = end - start
             chunk = min(remain_bytes, 64 - 3)
             resp = self._hid_xfer(
-                bytes([write_cmd, chunk]) + buffer[start : (start + chunk)], True
+                bytes([write_cmd, chunk]) + bytes(buffer[start : (start + chunk)]), True
             )
             if resp[1] != self.RESP_OK:
                 raise RuntimeError("SPI write error")


### PR DESCRIPTION
Fixes an issue that causes the ST7789 driver not to work with Pico U2IF