### PR TITLE
Add additional SPI ports for BCM2711

### DIFF
--- a/src/adafruit_blinka/microcontroller/bcm283x/pin.py
+++ b/src/adafruit_blinka/microcontroller/bcm283x/pin.py
@@ -142,6 +142,10 @@ spiPorts = (
     (0, SCLK, MOSI, MISO),
     (1, SCLK_1, MOSI_1, MISO_1),
     (2, SCLK_2, MOSI_2, MISO_2),
+    (3, D3, D2, D1), #SPI3 on Pi4/CM4
+    (4, D7, D6, D5), #SPI4 on Pi4/CM4
+    (5, D15, D14, D13), #SPI5 on Pi4/CM4
+    
 )
 
 # ordered as uartId, txId, rxId

--- a/src/adafruit_blinka/microcontroller/bcm283x/pin.py
+++ b/src/adafruit_blinka/microcontroller/bcm283x/pin.py
@@ -142,10 +142,9 @@ spiPorts = (
     (0, SCLK, MOSI, MISO),
     (1, SCLK_1, MOSI_1, MISO_1),
     (2, SCLK_2, MOSI_2, MISO_2),
-    (3, D3, D2, D1), #SPI3 on Pi4/CM4
-    (4, D7, D6, D5), #SPI4 on Pi4/CM4
-    (5, D15, D14, D13), #SPI5 on Pi4/CM4
-    
+    (3, D3, D2, D1),  # SPI3 on Pi4/CM4
+    (4, D7, D6, D5),  # SPI4 on Pi4/CM4
+    (5, D15, D14, D13),  # SPI5 on Pi4/CM4
 )
 
 # ordered as uartId, txId, rxId


### PR DESCRIPTION
Currently the additional SPI ports on the Pi4 or CM4 are not usable in Blinka without doing this change manually.
SPI6 uses the same pins as the default SPI1 pins.