### PR TITLE
Fix I2C writeto_then_readfrom when in_start > 0 in RP2040

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ bundles
 .eggs
 dist
 **/*.egg-info
+.vscode

--- a/src/adafruit_blinka/microcontroller/rp2040/i2c.py
+++ b/src/adafruit_blinka/microcontroller/rp2040/i2c.py
@@ -55,9 +55,8 @@ class I2C:
             self.writeto(address, buffer_out[out_start:out_end], stop=stop)
         else:
             self.writeto(address, buffer_out[out_start:], stop=stop)
-        read_buffer = buffer_in
+
+        if not in_end:
+            in_end = len(buffer_in)
+        read_buffer = memoryview(buffer_in)[in_start:in_end]
         self.readfrom_into(address, read_buffer, stop=stop)
-        if in_end:
-            buffer_in[in_start:in_end] = read_buffer[in_start:in_end]
-        else:
-            buffer_in[in_start:] = read_buffer[in_start:]


### PR DESCRIPTION
This should hopefully fix any libraries that use `adafruit_register` to access registers over I2C.

I've tested it with an Adafruit DPS310.

Please test it with other driver libraries that use `adafruit_register`.