### PR TITLE
Added BeagleBone StarLight to Blinka (GPIO, I2C working)

### DIFF
--- a/src/adafruit_blinka/board/beagleboard/beaglev_starlight.py
+++ b/src/adafruit_blinka/board/beagleboard/beaglev_starlight.py
@@ -1,0 +1,49 @@
+"""Pin definitions for the BeagleV StarLight."""
+
+from adafruit_blinka.microcontroller.starfive.JH71x0 import pin
+
+D0 = pin.D0
+D1 = pin.D1
+
+SDA = pin.I2C2_SDA
+SCL = pin.I2C2_SCL
+
+D4 = pin.D4
+D5 = pin.D5
+D6 = pin.D6
+
+D7 = pin.D7
+CE1 = pin.D7
+D8 = pin.D8
+CE0 = pin.D8
+D9 = pin.D9
+MISO = pin.SPI_MISO
+D10 = pin.D10
+MOSI = pin.SPI_MOSI
+D11 = pin.D11
+SCLK = pin.SPI_SCLK
+SCK = pin.SPI_SCLK
+
+D12 = pin.D12
+D13 = pin.D13
+
+D14 = pin.D14
+TXD = pin.UART_TX
+D15 = pin.D15
+RXD = pin.UART_RX
+# create alias for most of the examples
+TX = pin.UART_TX
+RX = pin.UART_RX
+
+D16 = pin.D16
+D17 = pin.D17
+D18 = pin.D18
+D19 = pin.D19
+D20 = pin.D20
+D21 = pin.D21
+D22 = pin.D22
+D23 = pin.D23
+D24 = pin.D24
+D25 = pin.D25
+D26 = pin.D26
+D27 = pin.D27

--- a/src/adafruit_blinka/microcontroller/starfive/JH71x0/__init__.py
+++ b/src/adafruit_blinka/microcontroller/starfive/JH71x0/__init__.py
@@ -1,0 +1,1 @@
+"""Definition for the StarFive JH71x0 chip"""

--- a/src/adafruit_blinka/microcontroller/starfive/JH71x0/pin.py
+++ b/src/adafruit_blinka/microcontroller/starfive/JH71x0/pin.py
@@ -1,0 +1,57 @@
+"""A Pin class for use with StarFive JH71x0."""
+
+from adafruit_blinka.microcontroller.generic_linux.libgpiod_pin import Pin
+
+D0 = Pin(9)
+D1 = Pin(10)
+D4 = Pin(46)
+D5 = Pin(8)
+D6 = Pin(6)
+D7 = Pin(11)
+D8 = Pin(15)
+D9 = Pin(16)
+D10 = Pin(18)
+D11 = Pin(12)
+D12 = Pin(7)
+D13 = Pin(5)
+D14 = Pin(14)
+D15 = Pin(13)
+D16 = Pin(4)
+D17 = Pin(44)
+D18 = Pin(45)
+D19 = Pin(3)
+D20 = Pin(2)
+D21 = Pin(0)
+D22 = Pin(20)
+D23 = Pin(21)
+D24 = Pin(19)
+D25 = Pin(17)
+D26 = Pin(1)
+D27 = Pin(22)
+
+# I2C
+I2C1_SDA = Pin(48)
+I2C1_SCL = Pin(47)
+I2C2_SDA = Pin(59)
+I2C2_SCL = Pin(60)
+I2C3_SDA = Pin(61)
+I2C3_SCL = Pin(62)
+
+# SPI
+SPI_MISO = D9
+SPI_MOSI = D10
+SPI_SCLK = D11
+
+# UART
+UART_TX = D14
+UART_RX = D15
+
+# ordered as i2cId, SCL, SDA
+i2cPorts = (
+    (0, I2C1_SCL, I2C1_SDA),
+    (1, I2C2_SCL, I2C2_SDA),
+    (2, I2C3_SCL, I2C3_SDA),
+)
+
+# ordered as spiId, sckId, mosiId, misoId
+spiPorts = ((0, SPI_SCLK, SPI_MOSI, SPI_MISO),)

--- a/src/board.py
+++ b/src/board.py
@@ -83,6 +83,9 @@ elif board_id == ap_board.BEAGLEBONE_POCKETBEAGLE:
 elif board_id == ap_board.BEAGLEBONE_AI:
     from adafruit_blinka.board.beagleboard.beaglebone_ai import *
 
+elif board_id == ap_board.BEAGLEV_STARLIGHT:
+    from adafruit_blinka.board.beagleboard.beaglev_starlight import *
+
 elif board_id == ap_board.ORANGE_PI_PC:
     from adafruit_blinka.board.orangepi.orangepipc import *
 

--- a/src/busio.py
+++ b/src/busio.py
@@ -279,47 +279,7 @@ class SPI(Lockable):
 
     def configure(self, baudrate=100000, polarity=0, phase=0, bits=8):
         """Update the configuration"""
-        if detector.board.any_raspberry_pi or detector.board.any_raspberry_pi_40_pin:
-            from adafruit_blinka.microcontroller.generic_linux.spi import SPI as _SPI
-        elif detector.board.BEAGLEBONE_AI:
-            from adafruit_blinka.microcontroller.generic_linux.spi import SPI as _SPI
-        elif detector.board.any_beaglebone:
-            from adafruit_blinka.microcontroller.generic_linux.spi import SPI as _SPI
-        elif detector.board.any_orange_pi:
-            from adafruit_blinka.microcontroller.generic_linux.spi import SPI as _SPI
-        elif detector.board.any_nanopi and detector.chip.id == ap_chip.SUN8I:
-            from adafruit_blinka.microcontroller.generic_linux.spi import SPI as _SPI
-        elif board_id == ap_board.GIANT_BOARD:
-            from adafruit_blinka.microcontroller.generic_linux.spi import SPI as _SPI
-        elif board_id == ap_board.CORAL_EDGE_TPU_DEV:
-            from adafruit_blinka.microcontroller.generic_linux.spi import SPI as _SPI
-        elif board_id == ap_board.CORAL_EDGE_TPU_DEV_MINI:
-            from adafruit_blinka.microcontroller.generic_linux.spi import SPI as _SPI
-        elif board_id == ap_board.ODROID_C2:
-            from adafruit_blinka.microcontroller.generic_linux.spi import SPI as _SPI
-        elif board_id == ap_board.ODROID_C4:
-            from adafruit_blinka.microcontroller.generic_linux.spi import SPI as _SPI
-        elif board_id == ap_board.ODROID_XU4:
-            from adafruit_blinka.microcontroller.generic_linux.spi import SPI as _SPI
-        elif board_id == ap_board.DRAGONBOARD_410C:
-            from adafruit_blinka.microcontroller.generic_linux.spi import SPI as _SPI
-        elif board_id == ap_board.JETSON_NANO:
-            from adafruit_blinka.microcontroller.generic_linux.spi import SPI as _SPI
-        elif board_id == ap_board.JETSON_TX1:
-            from adafruit_blinka.microcontroller.generic_linux.spi import SPI as _SPI
-        elif board_id == ap_board.JETSON_TX2:
-            from adafruit_blinka.microcontroller.generic_linux.spi import SPI as _SPI
-        elif board_id == ap_board.JETSON_XAVIER:
-            from adafruit_blinka.microcontroller.generic_linux.spi import SPI as _SPI
-        elif board_id == ap_board.JETSON_NX:
-            from adafruit_blinka.microcontroller.generic_linux.spi import SPI as _SPI
-        elif detector.board.ROCK_PI_S:
-            from adafruit_blinka.microcontroller.generic_linux.spi import SPI as _SPI
-        elif detector.board.ROCK_PI_4:
-            from adafruit_blinka.microcontroller.generic_linux.spi import SPI as _SPI
-        elif detector.board.ROCK_PI_E:
-            from adafruit_blinka.microcontroller.generic_linux.spi import SPI as _SPI
-        elif detector.board.SIFIVE_UNLEASHED:
+        if detector.board.any_nanopi and detector.chip.id == ap_chip.SUN8I:
             from adafruit_blinka.microcontroller.generic_linux.spi import SPI as _SPI
         elif detector.board.ftdi_ft232h:
             from adafruit_blinka.microcontroller.ftdi_mpsse.mpsse.spi import (
@@ -333,19 +293,6 @@ class SPI(Lockable):
             from adafruit_blinka.microcontroller.nova.spi import SPI as _SPI
         elif detector.board.greatfet_one:
             from adafruit_blinka.microcontroller.nxp_lpc4330.spi import SPI as _SPI
-        elif board_id in (
-            ap_board.PINE64,
-            ap_board.PINEBOOK,
-            ap_board.PINEPHONE,
-            ap_board.SOPINE,
-        ):
-            from adafruit_blinka.microcontroller.generic_linux.spi import SPI as _SPI
-        elif board_id == ap_board.PINEH64:
-            from adafruit_blinka.microcontroller.generic_linux.spi import SPI as _SPI
-        elif board_id == ap_board.CLOCKWORK_CPI3:
-            from adafruit_blinka.microcontroller.generic_linux.spi import SPI as _SPI
-        elif board_id == ap_board.ONION_OMEGA2:
-            from adafruit_blinka.microcontroller.generic_linux.spi import SPI as _SPI
         elif detector.board.any_lubancat and detector.chip.id == ap_chip.IMX6ULL:
             from adafruit_blinka.microcontroller.generic_linux.spi import SPI as _SPI
         elif detector.board.pico_u2if:
@@ -362,6 +309,8 @@ class SPI(Lockable):
             from adafruit_blinka.microcontroller.rp2040_u2if.spi import SPI_QTPY as _SPI
         elif detector.chip.id == ap_chip.RP2040:
             from adafruit_blinka.microcontroller.rp2040.spi import SPI as _SPI
+        elif detector.board.any_embedded_linux:
+            from adafruit_blinka.microcontroller.generic_linux.spi import SPI as _SPI
         else:
             from adafruit_blinka.microcontroller.generic_micropython.spi import (
                 SPI as _SPI,
@@ -389,10 +338,10 @@ class SPI(Lockable):
         """Return the baud rate if implemented"""
         try:
             return self._spi.frequency
-        except AttributeError:
+        except AttributeError as error:
             raise NotImplementedError(
                 "Frequency attribute not implemented for this platform"
-            ) from AttributeError
+            ) from error
 
     def write(self, buf, start=0, end=None):
         """Write to the SPI device"""

--- a/src/busio.py
+++ b/src/busio.py
@@ -12,6 +12,7 @@ try:
 except ImportError:
     threading = None
 
+# pylint: disable=unused-import
 import adafruit_platformdetect.constants.boards as ap_board
 import adafruit_platformdetect.constants.chips as ap_chip
 from adafruit_blinka import Enum, Lockable, agnostic

--- a/src/digitalio.py
+++ b/src/digitalio.py
@@ -15,6 +15,8 @@ if detector.chip.BCM2XXX:
     from adafruit_blinka.microcontroller.bcm283x.pin import Pin
 elif detector.chip.AM33XX:
     from adafruit_blinka.microcontroller.am335x.pin import Pin
+elif detector.chip.JH71x0:
+    from adafruit_blinka.microcontroller.starfive.JH71x0.pin import Pin
 elif detector.chip.DRA74X:
     from adafruit_blinka.microcontroller.dra74x.pin import Pin
 elif detector.chip.SUN8I:

--- a/src/microcontroller/__init__.py
+++ b/src/microcontroller/__init__.py
@@ -52,6 +52,8 @@ elif chip_id == ap_chip.DRA74X:
     from adafruit_blinka.microcontroller.dra74x.pin import *
 elif chip_id == ap_chip.AM33XX:
     from adafruit_blinka.microcontroller.am335x import *
+elif chip_id == ap_chip.JH71x0:
+    from adafruit_blinka.microcontroller.starfive.JH71x0 import *
 elif chip_id == ap_chip.SUN8I:
     from adafruit_blinka.microcontroller.allwinner.h3 import *
 elif chip_id == ap_chip.H5:
@@ -101,9 +103,9 @@ elif chip_id == ap_chip.BINHO:
 elif chip_id == ap_chip.LPC4330:
     from adafruit_blinka.microcontroller.nxp_lpc4330 import *
 elif chip_id == ap_chip.MIPS24KC:
-    from adafruit_blinka.microcontroller.atheros.ar9331.pin import *
+    from adafruit_blinka.microcontroller.atheros.ar9331 import *
 elif chip_id == ap_chip.MIPS24KEC:
-    from adafruit_blinka.microcontroller.mips24kec.pin import *
+    from adafruit_blinka.microcontroller.mips24kec import *
 elif chip_id == ap_chip.FT232H:
     from adafruit_blinka.microcontroller.ftdi_mpsse.ft232h.pin import *
 elif chip_id == ap_chip.FT2232H:

--- a/src/microcontroller/pin.py
+++ b/src/microcontroller/pin.py
@@ -18,6 +18,8 @@ elif chip_id == ap_chip.DRA74X:
     from adafruit_blinka.microcontroller.dra74x.pin import *
 elif chip_id == ap_chip.AM33XX:
     from adafruit_blinka.microcontroller.am335x.pin import *
+elif chip_id == ap_chip.JH71x0:
+    from adafruit_blinka.microcontroller.starfive.JH71x0.pin import *
 elif chip_id == ap_chip.SUN8I:
     from adafruit_blinka.microcontroller.allwinner.h3.pin import *
 elif chip_id == ap_chip.H5:


### PR DESCRIPTION
I added the new BeagleBone StarLight to Blinka and have GPIO and I2C working.
I also reduced the huge if/else tree in busio for SPI by making use of the any_embedded_linux property for anything else that's not caught ahead of that for loading up specialized constructors. That way we don't have an extra 20-30 if checks just to import the same line of code.