### PR TITLE
mcp2221: allow empty i2c payload

### DIFF
--- a/src/adafruit_blinka/microcontroller/mcp2221/mcp2221.py
+++ b/src/adafruit_blinka/microcontroller/mcp2221/mcp2221.py
@@ -198,7 +198,7 @@ class MCP2221:
         length = end - start
         retries = 0
 
-        while (end - start) > 0:
+        while (end - start) > 0 or not buffer:
             chunk = min(end - start, MCP2221_MAX_I2C_DATA_LEN)
             # write out current chunk
             resp = self._hid_xfer(
@@ -223,6 +223,8 @@ class MCP2221:
             # yay chunk sent!
             while self._i2c_state() == RESP_I2C_PARTIALDATA:
                 time.sleep(0.001)
+            if not buffer:
+                break
             start += chunk
             retries = 0
 

--- a/src/adafruit_blinka/microcontroller/mcp2221/mcp2221.py
+++ b/src/adafruit_blinka/microcontroller/mcp2221/mcp2221.py
@@ -189,7 +189,7 @@ class MCP2221:
             # bus release will need "a few hundred microseconds"
             time.sleep(0.001)
 
-    # pylint: disable=too-many-arguments
+    # pylint: disable=too-many-arguments,too-many-branches
     def _i2c_write(self, cmd, address, buffer, start=0, end=None):
         if self._i2c_state() != 0x00:
             self._i2c_cancel()


### PR DESCRIPTION
This fix allow sending I2C transactions with an empty payload.

Before this change, sending an empty payload is bogus as it won't transfer
anything but will still try to get the status of the transaction. It will
basically get the current status of the bus.

One way to manifest this problem is when connecting to a device.

On `I2CDevice` init, it will [probe the device by sending en empty payload](https://github.com/adafruit/Adafruit_CircuitPython_BusDevice/blob/b869a4a12618721f1232cbbec95a6186fb84ddf7/adafruit_bus_device/i2c_device.py#L154)
message. This actually works fine if the bus is in a good state like on
first use. It won't actually send the probe out but we will read the
good initial state and things will go smoothly from here.

However if we start by initializing a device with an address at which
there is no device, it won't send the empty payload probe but will fail
later on as there is no device at that address.

At this point the bus is basically in DoS as trying to init a device
will again not send the empty payload but now since the bus is in the
error state it will fail even if the device is in fact present.