### PR TITLE
Add versioning to the top-level Python files

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,5 +29,8 @@ jobs:
         TWINE_USERNAME: ${{ secrets.pypi_username }}
         TWINE_PASSWORD: ${{ secrets.pypi_password }}
       run: |
+        for file in $(find -not -path "./.*" -not -path "./docs*" -name "*.py"); do
+            sed -i -e "s/0.0.0-auto.0/${{github.event.release.tag_name}}/" $file;
+        done;
         python setup.py sdist
         twine upload dist/*

--- a/setup.py
+++ b/setup.py
@@ -33,8 +33,7 @@ if os.path.exists("/proc/device-tree/compatible"):
         board_reqs = ["RPi.GPIO", "rpi_ws281x>=4.0.0", "sysv_ipc>=1.1.0"]
 
 setup(
-    # name="Adafruit-Blinka",
-    name="samourai-Adafruit-Blinka",
+    name="Adafruit-Blinka",
     use_scm_version={
         # This is needed for the PyPI version munging in the Github Actions release.yml
         "git_describe_command": "git describe --tags --long",

--- a/setup.py
+++ b/setup.py
@@ -33,8 +33,13 @@ if os.path.exists("/proc/device-tree/compatible"):
         board_reqs = ["RPi.GPIO", "rpi_ws281x>=4.0.0", "sysv_ipc>=1.1.0"]
 
 setup(
-    name="Adafruit-Blinka",
-    use_scm_version=True,
+    # name="Adafruit-Blinka",
+    name="samourai-Adafruit-Blinka",
+    use_scm_version={
+        # This is needed for the PyPI version munging in the Github Actions release.yml
+        "git_describe_command": "git describe --tags --long",
+        "local_scheme": "no-local-version",
+    },
     setup_requires=["setuptools_scm"],
     description="CircuitPython APIs for non-CircuitPython versions of Python such as CPython on Linux and MicroPython.",
     long_description=long_description,
@@ -53,10 +58,11 @@ setup(
         "board",
         "busio",
         "digitalio",
+        "keypad",
         "micropython",
+        "neopixel_write",
         "pulseio",
         "pwmio",
-        "neopixel_write",
         "rainbowio",
     ],
     package_data={

--- a/src/analogio.py
+++ b/src/analogio.py
@@ -7,6 +7,11 @@ Not supported by all boards.
 * Author(s): Carter Nelson, Melissa LeBlanc-Williams
 """
 
+
+__version__ = "0.0.0-auto.0"
+__repo__ = "https://github.com/adafruit/Adafruit_Blinka.git"
+
+
 import sys
 
 from adafruit_blinka.agnostic import detector

--- a/src/bitbangio.py
+++ b/src/bitbangio.py
@@ -7,6 +7,11 @@ See `CircuitPython:bitbangio` in CircuitPython for more details.
 * Author(s): cefn
 """
 
+
+__version__ = "0.0.0-auto.0"
+__repo__ = "https://github.com/adafruit/Adafruit_Blinka.git"
+
+
 import adafruit_platformdetect.constants.boards as ap_board
 from adafruit_blinka import Lockable, agnostic
 

--- a/src/board.py
+++ b/src/board.py
@@ -31,6 +31,7 @@ See `CircuitPython:board` in CircuitPython for more details.
 
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_Blinka.git"
+__blinka__ = True
 
 
 import sys

--- a/src/board.py
+++ b/src/board.py
@@ -27,6 +27,12 @@ See `CircuitPython:board` in CircuitPython for more details.
 
 * Author(s): cefn
 """
+
+
+__version__ = "0.0.0-auto.0"
+__repo__ = "https://github.com/adafruit/Adafruit_Blinka.git"
+
+
 import sys
 
 import adafruit_platformdetect.constants.boards as ap_board

--- a/src/busio.py
+++ b/src/busio.py
@@ -7,6 +7,11 @@ See `CircuitPython:busio` in CircuitPython for more details.
 * Author(s): cefn
 """
 
+
+__version__ = "0.0.0-auto.0"
+__repo__ = "https://github.com/adafruit/Adafruit_Blinka.git"
+
+
 try:
     import threading
 except ImportError:

--- a/src/digitalio.py
+++ b/src/digitalio.py
@@ -7,6 +7,11 @@ See `CircuitPython:digitalio` in CircuitPython for more details.
 * Author(s): cefn
 """
 
+
+__version__ = "0.0.0-auto.0"
+__repo__ = "https://github.com/adafruit/Adafruit_Blinka.git"
+
+
 from adafruit_blinka.agnostic import board_id, detector
 
 # pylint: disable=ungrouped-imports,wrong-import-position

--- a/src/keypad.py
+++ b/src/keypad.py
@@ -6,6 +6,11 @@ See `CircuitPython:keypad` in CircuitPython for more details.
 * Author(s): Melissa LeBlanc-Williams
 """
 
+
+__version__ = "0.0.0-auto.0"
+__repo__ = "https://github.com/adafruit/Adafruit_Blinka.git"
+
+
 import time
 import threading
 from collections import deque

--- a/src/micropython.py
+++ b/src/micropython.py
@@ -6,6 +6,10 @@
 """
 
 
+__version__ = "0.0.0-auto.0"
+__repo__ = "https://github.com/adafruit/Adafruit_Blinka.git"
+
+
 def const(x):
     "Emulate making a constant"
     return x

--- a/src/neopixel_write.py
+++ b/src/neopixel_write.py
@@ -8,6 +8,11 @@ Currently supported on Raspberry Pi only.
 * Author(s): ladyada
 """
 
+
+__version__ = "0.0.0-auto.0"
+__repo__ = "https://github.com/adafruit/Adafruit_Blinka.git"
+
+
 import sys
 
 from adafruit_blinka.agnostic import detector

--- a/src/pulseio.py
+++ b/src/pulseio.py
@@ -7,6 +7,11 @@ Not supported by all boards.
 * Author(s): Melissa LeBlanc-Williams
 """
 
+
+__version__ = "0.0.0-auto.0"
+__repo__ = "https://github.com/adafruit/Adafruit_Blinka.git"
+
+
 import sys
 
 from adafruit_blinka.agnostic import detector

--- a/src/pwmio.py
+++ b/src/pwmio.py
@@ -7,6 +7,11 @@ Not supported by all boards.
 * Author(s): Melissa LeBlanc-Williams
 """
 
+
+__version__ = "0.0.0-auto.0"
+__repo__ = "https://github.com/adafruit/Adafruit_Blinka.git"
+
+
 import sys
 
 from adafruit_blinka.agnostic import detector

--- a/src/rainbowio.py
+++ b/src/rainbowio.py
@@ -8,6 +8,10 @@ Not supported by all boards.
 """
 
 
+__version__ = "0.0.0-auto.0"
+__repo__ = "https://github.com/adafruit/Adafruit_Blinka.git"
+
+
 def colorwheel(color_value):
     """
     A colorwheel. ``0`` and ``255`` are red, ``85`` is green, and ``170`` is blue, with the values


### PR DESCRIPTION
Add version munging to the top-level Python files so that when a new version is released the files uploaded to PyPI will have a `__version__` and `__repo__` variable similar to the CircuitPython ones.

eg, `busio.__version__ = 6.14.0`

There is also a special variable only added to `board` for now:
`board.__blinka__ = True`
This is to make it easy for a library to determine if it is being run on Blinka.

Tested by uploading a dummy release to:
https://pypi.org/project/samourai-Adafruit-Blinka/