### PR TITLE
Revert "Add versioning to the top-level Python files"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,8 +29,5 @@ jobs:
         TWINE_USERNAME: ${{ secrets.pypi_username }}
         TWINE_PASSWORD: ${{ secrets.pypi_password }}
       run: |
-        for file in $(find -not -path "./.*" -not -path "./docs*" -name "*.py"); do
-            sed -i -e "s/0.0.0-auto.0/${{github.event.release.tag_name}}/" $file;
-        done;
         python setup.py sdist
         twine upload dist/*

--- a/setup.py
+++ b/setup.py
@@ -34,11 +34,7 @@ if os.path.exists("/proc/device-tree/compatible"):
 
 setup(
     name="Adafruit-Blinka",
-    use_scm_version={
-        # This is needed for the PyPI version munging in the Github Actions release.yml
-        "git_describe_command": "git describe --tags --long",
-        "local_scheme": "no-local-version",
-    },
+    use_scm_version=True,
     setup_requires=["setuptools_scm"],
     description="CircuitPython APIs for non-CircuitPython versions of Python such as CPython on Linux and MicroPython.",
     long_description=long_description,
@@ -57,11 +53,10 @@ setup(
         "board",
         "busio",
         "digitalio",
-        "keypad",
         "micropython",
-        "neopixel_write",
         "pulseio",
         "pwmio",
+        "neopixel_write",
         "rainbowio",
     ],
     package_data={

--- a/src/analogio.py
+++ b/src/analogio.py
@@ -7,11 +7,6 @@ Not supported by all boards.
 * Author(s): Carter Nelson, Melissa LeBlanc-Williams
 """
 
-
-__version__ = "0.0.0-auto.0"
-__repo__ = "https://github.com/adafruit/Adafruit_Blinka.git"
-
-
 import sys
 
 from adafruit_blinka.agnostic import detector

--- a/src/bitbangio.py
+++ b/src/bitbangio.py
@@ -7,11 +7,6 @@ See `CircuitPython:bitbangio` in CircuitPython for more details.
 * Author(s): cefn
 """
 
-
-__version__ = "0.0.0-auto.0"
-__repo__ = "https://github.com/adafruit/Adafruit_Blinka.git"
-
-
 import adafruit_platformdetect.constants.boards as ap_board
 from adafruit_blinka import Lockable, agnostic
 

--- a/src/board.py
+++ b/src/board.py
@@ -27,13 +27,6 @@ See `CircuitPython:board` in CircuitPython for more details.
 
 * Author(s): cefn
 """
-
-
-__version__ = "0.0.0-auto.0"
-__repo__ = "https://github.com/adafruit/Adafruit_Blinka.git"
-__blinka__ = True
-
-
 import sys
 
 import adafruit_platformdetect.constants.boards as ap_board

--- a/src/busio.py
+++ b/src/busio.py
@@ -7,11 +7,6 @@ See `CircuitPython:busio` in CircuitPython for more details.
 * Author(s): cefn
 """
 
-
-__version__ = "0.0.0-auto.0"
-__repo__ = "https://github.com/adafruit/Adafruit_Blinka.git"
-
-
 try:
     import threading
 except ImportError:

--- a/src/digitalio.py
+++ b/src/digitalio.py
@@ -7,11 +7,6 @@ See `CircuitPython:digitalio` in CircuitPython for more details.
 * Author(s): cefn
 """
 
-
-__version__ = "0.0.0-auto.0"
-__repo__ = "https://github.com/adafruit/Adafruit_Blinka.git"
-
-
 from adafruit_blinka.agnostic import board_id, detector
 
 # pylint: disable=ungrouped-imports,wrong-import-position

--- a/src/keypad.py
+++ b/src/keypad.py
@@ -6,11 +6,6 @@ See `CircuitPython:keypad` in CircuitPython for more details.
 * Author(s): Melissa LeBlanc-Williams
 """
 
-
-__version__ = "0.0.0-auto.0"
-__repo__ = "https://github.com/adafruit/Adafruit_Blinka.git"
-
-
 import time
 import threading
 from collections import deque

--- a/src/micropython.py
+++ b/src/micropython.py
@@ -6,10 +6,6 @@
 """
 
 
-__version__ = "0.0.0-auto.0"
-__repo__ = "https://github.com/adafruit/Adafruit_Blinka.git"
-
-
 def const(x):
     "Emulate making a constant"
     return x

--- a/src/neopixel_write.py
+++ b/src/neopixel_write.py
@@ -8,11 +8,6 @@ Currently supported on Raspberry Pi only.
 * Author(s): ladyada
 """
 
-
-__version__ = "0.0.0-auto.0"
-__repo__ = "https://github.com/adafruit/Adafruit_Blinka.git"
-
-
 import sys
 
 from adafruit_blinka.agnostic import detector

--- a/src/pulseio.py
+++ b/src/pulseio.py
@@ -7,11 +7,6 @@ Not supported by all boards.
 * Author(s): Melissa LeBlanc-Williams
 """
 
-
-__version__ = "0.0.0-auto.0"
-__repo__ = "https://github.com/adafruit/Adafruit_Blinka.git"
-
-
 import sys
 
 from adafruit_blinka.agnostic import detector

--- a/src/pwmio.py
+++ b/src/pwmio.py
@@ -7,11 +7,6 @@ Not supported by all boards.
 * Author(s): Melissa LeBlanc-Williams
 """
 
-
-__version__ = "0.0.0-auto.0"
-__repo__ = "https://github.com/adafruit/Adafruit_Blinka.git"
-
-
 import sys
 
 from adafruit_blinka.agnostic import detector

--- a/src/rainbowio.py
+++ b/src/rainbowio.py
@@ -8,10 +8,6 @@ Not supported by all boards.
 """
 
 
-__version__ = "0.0.0-auto.0"
-__repo__ = "https://github.com/adafruit/Adafruit_Blinka.git"
-
-
 def colorwheel(color_value):
     """
     A colorwheel. ``0`` and ``255`` are red, ``85`` is green, and ``170`` is blue, with the values


### PR DESCRIPTION
Reverts adafruit/Adafruit_Blinka#508. We realized this shouldhave only applied to board.