### PR TITLE
Add MacroPad RP2040 u2if

### DIFF
--- a/src/adafruit_blinka/board/macropad_u2if.py
+++ b/src/adafruit_blinka/board/macropad_u2if.py
@@ -1,0 +1,58 @@
+"""
+Pin definitions for the MacroPad RP2040 with u2if firmware.
+
+Adafruit CircuitPython 6.2.0 on 2021-04-05; Adafruit MacroPad RP2040 with rp2040
+>>> import board
+>>> board.
+KEY1            KEY2            KEY3            KEY4
+KEY5            KEY6            KEY7            KEY8
+KEY9            KEY10           KEY11           KEY12
+LED             SPEAKER_ENABLE  SPEAKER         ENCODER_SWITCH
+BUTTON          ENCODER_A       ROTA            ENCODER_B
+ROTB            NEOPIXEL        SDA             SCL
+OLED_CS         OLED_RESET      OLED_DC         SCLK
+SCK             MOSI            MISO            I2C
+SPI             UART
+"""
+
+from adafruit_blinka.microcontroller.rp2040_u2if import pin
+
+KEY1 = pin.GP1
+KEY2 = pin.GP2
+KEY3 = pin.GP3
+KEY4 = pin.GP4
+KEY5 = pin.GP5
+KEY6 = pin.GP6
+KEY7 = pin.GP7
+KEY8 = pin.GP8
+KEY9 = pin.GP9
+KEY10 = pin.GP10
+KEY11 = pin.GP11
+KEY12 = pin.GP12
+
+LED = pin.GP13
+
+SPEAKER_ENABLE = pin.GP4
+SPEAKER = pin.GP16
+
+ENCODER_SWITCH = BUTTON = pin.GP0
+
+ENCODER_A = ROTA = pin.GP17
+ENCODER_B = ROTB = pin.GP18
+
+NEOPIXEL = pin.GP19
+
+SDA = pin.GP20
+SCL = pin.GP21
+
+OLED_CS = pin.GP22
+OLED_RESET = pin.GP23
+OLED_DC = pin.GP24
+
+SCLK = SCK = pin.GP26
+MOSI = pin.GP27
+MISO = pin.GP28
+
+# access u2if via pin instance to open for specifc VID/PID
+# pylint:disable = protected-access
+pin.GP0._u2if_open_hid(0x239A, 0x0000)

--- a/src/adafruit_blinka/microcontroller/rp2040_u2if/i2c.py
+++ b/src/adafruit_blinka/microcontroller/rp2040_u2if/i2c.py
@@ -114,6 +114,17 @@ class I2C_ItsyBitsy(I2C):
 
         super().__init__(index, frequency=frequency)
 
+class I2C_MacroPad(I2C):
+    """I2C Class for MacroPad u2if"""
+
+    def __init__(self, scl, sda, *, frequency=100000):
+        index = None
+        if scl.id == 21 and sda.id == 20:
+            index = 0
+        if index is None:
+            raise ValueError("I2C not found on specified pins.")
+        self._index = index
+        super().__init__(index, frequency=frequency)
 
 class I2C_QT2040_Trinkey(I2C):
     """I2C Class for QT2040 Trinkey u2if"""

--- a/src/adafruit_blinka/microcontroller/rp2040_u2if/spi.py
+++ b/src/adafruit_blinka/microcontroller/rp2040_u2if/spi.py
@@ -112,3 +112,14 @@ class SPI_ItsyBitsy(SPI):
         if index is None:
             raise ValueError("No SPI port on specified pin.")
         super().__init__(index, baudrate=baudrate)
+
+class SPI_MacroPad(SPI):
+    """SPI Class for MacroPad u2if"""
+
+    def __init__(self, clock, *, baudrate=100000):
+        index = None
+        if clock.id == 26:
+            index = 1
+        if index is None:
+            raise ValueError("No SPI port on specified pin.")
+        super().__init__(index, baudrate=baudrate)

--- a/src/board.py
+++ b/src/board.py
@@ -246,6 +246,9 @@ elif board_id == ap_board.QTPY_U2IF:
 elif board_id == ap_board.ITSYBITSY_U2IF:
     from adafruit_blinka.board.itsybitsy_u2if import *
 
+elif board_id == ap_board.MACROPAD_U2IF:
+    from adafruit_blinka.board.macropad_u2if import *
+
 elif board_id == ap_board.QT2040_TRINKEY_U2IF:
     from adafruit_blinka.board.qt2040_trinkey_u2if import *
 

--- a/src/busio.py
+++ b/src/busio.py
@@ -78,6 +78,12 @@ class I2C(Lockable):
 
             self._i2c = _I2C(scl, sda, frequency=frequency)
             return
+        if detector.board.macropad_u2if:
+            from adafruit_blinka.microcontroller.rp2040_u2if.i2c import (
+                I2C_MacroPad as _I2C,
+            )
+            self._i2c = _I2C(scl, sda, frequency=frequency)
+            return
         if detector.board.qt2040_trinkey_u2if:
             from adafruit_blinka.microcontroller.rp2040_u2if.i2c import (
                 I2C_QT2040_Trinkey as _I2C,
@@ -240,6 +246,14 @@ class SPI(Lockable):
             self._spi = _SPI(clock)  # this is really all that's needed
             self._pins = (clock, clock, clock)  # will determine MOSI/MISO from clock
             return
+        if detector.board.macropad_u2if:
+            from adafruit_blinka.microcontroller.rp2040_u2if.spi import (
+                SPI_MacroPad as _SPI,
+            )
+
+            self._spi = _SPI(clock)  # this is really all that's needed
+            self._pins = (clock, clock, clock)  # will determine MOSI/MISO from clock
+            return
         if detector.board.qtpy_u2if:
             from adafruit_blinka.microcontroller.rp2040_u2if.spi import SPI_QTPY as _SPI
 
@@ -305,6 +319,10 @@ class SPI(Lockable):
         elif detector.board.itsybitsy_u2if:
             from adafruit_blinka.microcontroller.rp2040_u2if.spi import (
                 SPI_ItsyBitsy as _SPI,
+            )
+        elif detector.board.macropad_u2if:
+            from adafruit_blinka.microcontroller.rp2040_u2if.spi import (
+                SPI_Macropad as _SPI,
             )
         elif detector.board.qtpy_u2if:
             from adafruit_blinka.microcontroller.rp2040_u2if.spi import SPI_QTPY as _SPI

--- a/src/digitalio.py
+++ b/src/digitalio.py
@@ -89,6 +89,7 @@ elif (
     detector.board.feather_u2if
     or detector.board.qtpy_u2if
     or detector.board.itsybitsy_u2if
+    or detector.board.macropad_u2if
     or detector.board.qt2040_trinkey_u2if
 ):
     from adafruit_blinka.microcontroller.rp2040_u2if.pin import Pin

--- a/src/microcontroller/__init__.py
+++ b/src/microcontroller/__init__.py
@@ -126,6 +126,8 @@ elif chip_id == ap_chip.STM32MP157:
     from adafruit_blinka.microcontroller.stm32.stm32mp157.pin import *
 elif chip_id == ap_chip.MT8167:
     from adafruit_blinka.microcontroller.mt8167.pin import *
+elif chip_id == ap_chip.RP2040_U2IF:
+    from adafruit_blinka.microcontroller.rp2040_u2if.pin import *
 elif "sphinx" in sys.modules:
     pass
 else:

--- a/src/neopixel_write.py
+++ b/src/neopixel_write.py
@@ -20,6 +20,7 @@ elif (
     detector.board.feather_u2if
     or detector.board.qtpy_u2if
     or detector.board.itsybitsy_u2if
+    or detector.board.macropad_u2if
     or detector.board.qt2040_trinkey_u2if
 ):
     from adafruit_blinka.microcontroller.rp2040_u2if import neopixel as _neopixel

--- a/src/pwmio.py
+++ b/src/pwmio.py
@@ -35,6 +35,7 @@ elif (
     detector.board.feather_u2if
     or detector.board.qtpy_u2if
     or detector.board.itsybitsy_u2if
+    or detector.board.macropad_u2if
     or detector.board.qt2040_trinkey_u2if
 ):
     from adafruit_blinka.microcontroller.rp2040_u2if.pwmio import PWMOut


### PR DESCRIPTION
This adds support for the MacroPad RP2040 u2if. This relies on getting a new USB PID for it as well as merging of the following two PRs.

1. https://github.com/execuc/u2if/pull/7
2. https://github.com/adafruit/Adafruit_Python_PlatformDetect/pull/185