### PR TITLE
change actions to use python 3.7

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,10 +13,10 @@ jobs:
     - name: Translate Repo Name For Build Tools filename_prefix
       id: repo-name
       run: echo ::set-output name=repo-name::Adafruit-Blinka
-    - name: Set up Python 3.6
+    - name: Set up Python 3.7
       uses: actions/setup-python@v1
       with:
-        python-version: 3.6
+        python-version: 3.7
     - name: Versions
       run: |
         python3 --version

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,7 +29,7 @@ autodoc_mock_imports = [
 ]
 
 intersphinx_mapping = {
-    "python": ("https://docs.python.org/3.6", None),
+    "python": ("https://docs.python.org/3.7", None),
     "CircuitPython": ("https://circuitpython.readthedocs.io/en/latest/", None),
 }
 

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
     long_description_content_type="text/x-rst",
     author="Adafruit Industries",
     author_email="circuitpython@adafruit.com",
-    python_requires=">=3.6.0",
+    python_requires=">=3.7.0",
     url="https://github.com/adafruit/Adafruit_Blinka",
     package_dir={"": "src"},
     packages=find_packages("src"),
@@ -80,7 +80,7 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: Implementation :: MicroPython",
     ],
 )


### PR DESCRIPTION
This updates the version of python that will get used in the actions container to 3.7. This is needed to avoid an issue currently affecting debian builds. It's discussed a bit more here: https://github.com/adafruit/Adafruit_Blinka_Displayio/pull/73