### PR TITLE
#525 Add Beaglebone Green Gateway Board Support

### DIFF
--- a/src/board.py
+++ b/src/board.py
@@ -82,6 +82,9 @@ elif board_id == ap_board.BEAGLEBONE_BLACK:
 elif board_id == ap_board.BEAGLEBONE_GREEN:
     from adafruit_blinka.board.beagleboard.beaglebone_black import *
 
+elif board_id == ap_board.BEAGLEBONE_GREEN_GATEWAY:
+    from adafruit_blinka.board.beagleboard.beaglebone_black import *
+
 elif board_id == ap_board.BEAGLEBONE_BLACK_INDUSTRIAL:
     from adafruit_blinka.board.beagleboard.beaglebone_black import *
 


### PR DESCRIPTION
Hello Adafruit Blinka maintainers team! 

I have a [Beaglebone Green Gateway board](https://www.seeedstudio.com/SeeedStudio-BeagleBone-Green-Gateway-p-4586.html) that I would like to use Blinka on! It seems trivial to add it, so I've added support here using the same pattern that is used to add support for the Beaglebone Green!

I have submitted my change here. Let me know if this looks good or if anything needs changing!