### PR TITLE
Close the mcp2221 device before exit.

### DIFF
--- a/src/adafruit_blinka/microcontroller/mcp2221/mcp2221.py
+++ b/src/adafruit_blinka/microcontroller/mcp2221/mcp2221.py
@@ -55,14 +55,7 @@ class MCP2221:
         # make sure the device gets closed before exit
         atexit.register(self.close)
         if MCP2221_RESET_DELAY >= 0:
-            try:
-                self._reset()
-            except OSError:
-                # this might fail on Linux with the hid_mcp2221 native
-                # driver and a short reset delay -- if it fails,
-                # close the device before reraising
-                self.close()
-                raise
+            self._reset()
         self._gp_config = [0x07] * 4  # "don't care" initial value
         for pin in range(4):
             self.gp_set_mode(pin, self.GP_GPIO)  # set to GPIO mode

--- a/src/adafruit_blinka/microcontroller/mcp2221/mcp2221.py
+++ b/src/adafruit_blinka/microcontroller/mcp2221/mcp2221.py
@@ -2,6 +2,7 @@
 
 import os
 import time
+import atexit
 import hid
 
 # Here if you need it
@@ -51,12 +52,29 @@ class MCP2221:
     def __init__(self):
         self._hid = hid.device()
         self._hid.open(MCP2221.VID, MCP2221.PID)
+        # make sure the device gets closed before exit
+        atexit.register(self.close)
         if MCP2221_RESET_DELAY >= 0:
-            self._reset()
+            try:
+                self._reset()
+            except OSError:
+                # this might fail on Linux with the hid_mcp2221 native
+                # driver and a short reset delay -- if it fails,
+                # close the device before reraising
+                self.close()
+                raise
         self._gp_config = [0x07] * 4  # "don't care" initial value
         for pin in range(4):
             self.gp_set_mode(pin, self.GP_GPIO)  # set to GPIO mode
             self.gpio_set_direction(pin, 1)  # set to INPUT
+
+    def close(self):
+        """Close the device. Does nothing if the device is not open."""
+        self._hid.close()
+
+    def __del__(self):
+        # try to close the device before destroying the instance
+        self.close()
 
     def _hid_xfer(self, report, response=True):
         """Perform HID Transfer"""

--- a/src/adafruit_blinka/microcontroller/mcp2221/mcp2221.py
+++ b/src/adafruit_blinka/microcontroller/mcp2221/mcp2221.py
@@ -3,6 +3,7 @@
 import os
 import time
 import atexit
+
 import hid
 
 # Here if you need it
@@ -62,7 +63,7 @@ class MCP2221:
             self.gpio_set_direction(pin, 1)  # set to INPUT
 
     def close(self):
-        """Close the device. Does nothing if the device is not open."""
+        """Close the hid device. Does nothing if the device is not open."""
         self._hid.close()
 
     def __del__(self):


### PR DESCRIPTION
This PR addresses the first point of #536.  The [`hidapi` docs](https://trezor.github.io/cython-hidapi/api.html#hid.device.close) mention explicitly that `device.close()` "should always be called after opening a connection".

To address this issue, I first created a new public `MCP2221.close()` method.  This has three advantages:
1. the user can close the device directly;
2. the method can be used as a callback to close the currently-open device (using `atexit.register(self._hid.close)` doesn't work if `self._hid` gets reassigned);
3. the class becomes usable as a context manager through `contextlib.closing` (even though it might be better to explicitly support the context-manager protocol by adding `__enter__` and `__exit__`).

I then called this method in 3 places, to ensure the device is closed:
1. In a `try/except` around the `self._reset()` call in the `__init__`;
2. In `MCP2221.__del__`, called when the instance is destroyed (note that this is not guaranteed);
3. on program exit (using `atexit`).

Calling `.close()` on an already closed device does nothing, so the extra redundancy that might cause multiple calls to `.close()` shouldn't be an issue.

