### PR TITLE
Missing Pin imports for the MCP2221

### DIFF
--- a/src/microcontroller/__init__.py
+++ b/src/microcontroller/__init__.py
@@ -121,6 +121,8 @@ elif chip_id == ap_chip.BINHO:
     from adafruit_blinka.microcontroller.nova import *
 elif chip_id == ap_chip.LPC4330:
     from adafruit_blinka.microcontroller.nxp_lpc4330 import *
+elif chip_id == ap_chip.MCP2221:
+    from adafruit_blinka.microcontroller.mcp2221.pin import *
 elif chip_id == ap_chip.MIPS24KC:
     from adafruit_blinka.microcontroller.atheros.ar9331 import *
 elif chip_id == ap_chip.MIPS24KEC:


### PR DESCRIPTION
Hi,

I am using the Adafruit MCP2221 breakout board to connect my Mac to I2C devices.

However when I try to import the library adafruit_ads1x15 it would raise the following error:
NotImplementedError: ('Microcontroller not supported:', 'MCP2221')

I noticed that the import in the __init__.py for the MCP2221 was missing compared to what is in pin.py.
After adding the missing import, I was able to use the ADS1015 with the MCP2221 as expected.

I checked if there were any other missing imports, and there were none. The only thing was that __init__.py prints a warning for GENERIC_X86 whereas pin.py doesn't.

Not really sure what the process is for testings etc. on this repository. If there are specific guidelines on raising a PR, then please let me know.

Kind regards,
Andre