### PR TITLE
Add MCP2221 pin definitions to init

### DIFF
--- a/src/microcontroller/__init__.py
+++ b/src/microcontroller/__init__.py
@@ -137,6 +137,8 @@ elif chip_id == ap_chip.MT8167:
     from adafruit_blinka.microcontroller.mt8167.pin import *
 elif chip_id == ap_chip.RP2040_U2IF:
     from adafruit_blinka.microcontroller.rp2040_u2if.pin import *
+elif chip_id == ap_chip.MCP2221:
+    from adafruit_blinka.microcontroller.mcp2221.pin import *
 elif chip_id == ap_chip.GENERIC_X86:
     print("WARNING: GENERIC_X86 is not fully supported. Some features may not work.")
 elif "sphinx" in sys.modules:


### PR DESCRIPTION
I am working on getting [Adafruit Blinka DisplayIO](https://github.com/adafruit/Adafruit_Blinka_Displayio/) working with the [MCP2221A breakout](https://www.adafruit.com/product/4471). The first step is addressing a missing import of the MCP2221A pins in the Blinka init.

## Dependencies

- Adafruit Blinka (set up to use the MCP2221A)
- Adafruit Blinka displayio

## Issue

Here's what I did:

```
import board
import displayio
```

The error that was returned was:

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/george_w/.pyenv/versions/blinka/lib/python3.10/site-packages/displayio/__init__.py", line 21, in <module>
    from ._fourwire import FourWire
  File "/Users/george_w/.pyenv/versions/blinka/lib/python3.10/site-packages/displayio/_fourwire.py", line 24, in <module>
    import microcontroller
  File "/Users/george_w/.pyenv/versions/blinka/lib/python3.10/site-packages/microcontroller/__init__.py", line 147, in <module>
    raise NotImplementedError("Microcontroller not supported:", chip_id)
NotImplementedError: ('Microcontroller not supported:', 'MCP2221')
```

## Fix

Add the definition for the MCP2221 pins to `microcontroller/__init__.py`. I have done that here, and successfully tested displayio with Blinka running on MacOS 12.1 running with the MCP2221A breakout. There are a few other issues, but they're in the Blinka DisplayIO module and I'll address them there.