### PR TITLE
Add typing module(s) to Blinka

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -4,8 +4,11 @@
 .. If your library file(s) are nested in a directory (e.g. /adafruit_foo/foo.py)
 .. use this format as the module name: "adafruit_foo.foo"
 
+.. automodule:: _typing
+  :members
+
 .. automodule:: adafruit_blinka
-   :members:
+  :members:
 
 .. automodule:: adafruit_blinka.agnostic
   :members:
@@ -23,6 +26,9 @@
   :members:
 
 .. automodule:: busio
+  :members:
+
+.. automodule:: circuitpython_typing
   :members:
 
 .. automodule:: digitalio

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -5,7 +5,7 @@
 .. use this format as the module name: "adafruit_foo.foo"
 
 .. automodule:: _typing
-  :members
+  :members:
 
 .. automodule:: adafruit_blinka
   :members:

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,0 @@
-# SPDX-FileCopyrightText: 2021 Kattni Rembor for Adafruit Industries
-#
-# SPDX-License-Identifier: Unlicense
-
-numpy>=1.21.5

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,4 +3,4 @@
 # SPDX-License-Identifier: Unlicense
 
 sphinx>=4.0.0
-numpy
+numpy>=1.22.1

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: 2021 Kattni Rembor for Adafruit Industries
+#
+# SPDX-License-Identifier: Unlicense
+
+numpy>=1.21.5

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: 2021 Kattni Rembor for Adafruit Industries
+#
+# SPDX-License-Identifier: Unlicense
+
+sphinx>=4.0.0
+numpy

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,0 @@
-# SPDX-FileCopyrightText: 2021 Kattni Rembor for Adafruit Industries
-#
-# SPDX-License-Identifier: Unlicense
-
-sphinx>=4.0.0
-numpy>=1.22.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ rpi_ws281x>=4.0.0; platform_machine=='armv7l' or platform_machine=='armv6l'
 sysv_ipc>=1.1.0; sys_platform == 'linux' and platform_machine!='mips'
 pyftdi>=0.40.0
 binho-host-adapter>=0.1.6
+numpy>=1.22.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ rpi_ws281x>=4.0.0; platform_machine=='armv7l' or platform_machine=='armv6l'
 sysv_ipc>=1.1.0; sys_platform == 'linux' and platform_machine!='mips'
 pyftdi>=0.40.0
 binho-host-adapter>=0.1.6
-numpy>=1.22.1
+numpy>=1.21.5

--- a/setup.py
+++ b/setup.py
@@ -52,10 +52,12 @@ setup(
     # py_modules lists top-level single file packages to include.
     # find_packages only finds packages in directories with __init__.py files.
     py_modules=[
+        "_typing",
         "analogio",
         "bitbangio",
         "board",
         "busio",
+        "circuitpython_typing",
         "digitalio",
         "keypad",
         "micropython",

--- a/src/_typing.py
+++ b/src/_typing.py
@@ -23,7 +23,7 @@
 `_typing` - Define (legacy) subset of types for C-level protocols
 =================================================================
 
-See `CircuitPython:_typing` in CircuitPython for more details.
+See `CircuitPython:circuitpython_typing` in CircuitPython for more details.
 
 * Author(s): Alec Delaney
 """

--- a/src/_typing.py
+++ b/src/_typing.py
@@ -28,4 +28,4 @@ See `CircuitPython:board` in CircuitPython for more details.
 * Author(s): Alec Delaney
 """
 
-from circuitpython_typing import *
+from circuitpython_typing import *  # pylint: disable=wildcard-import,unused-wildcard-import

--- a/src/_typing.py
+++ b/src/_typing.py
@@ -21,7 +21,7 @@
 # THE SOFTWARE.
 """
 `_typing` - Define (legacy) subset of types for C-level protocols
-======================================================
+=================================================================
 
 See `CircuitPython:board` in CircuitPython for more details.
 

--- a/src/_typing.py
+++ b/src/_typing.py
@@ -1,0 +1,31 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2017 cefn for adafruit industries
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+"""
+`_typing` - Define (legacy) subset of types for C-level protocols
+======================================================
+
+See `CircuitPython:board` in CircuitPython for more details.
+
+* Author(s): Alec Delaney
+"""
+
+from circuitpython_typing import *

--- a/src/_typing.py
+++ b/src/_typing.py
@@ -23,7 +23,7 @@
 `_typing` - Define (legacy) subset of types for C-level protocols
 =================================================================
 
-See `CircuitPython:board` in CircuitPython for more details.
+See `CircuitPython:_typing` in CircuitPython for more details.
 
 * Author(s): Alec Delaney
 """

--- a/src/circuitpython_typing.py
+++ b/src/circuitpython_typing.py
@@ -38,7 +38,7 @@ ReadableBuffer = Union[bytes, bytearray, memoryview, array, ndarray]
   - `bytearray`
   - `memoryview`
   - `array.array`
-  - `numpy.ndarray`
+  - ``numpy.ndarray``
 """
 
 WriteableBuffer = Union[bytearray, memoryview, array, ndarray]
@@ -46,5 +46,5 @@ WriteableBuffer = Union[bytearray, memoryview, array, ndarray]
   - `bytearray`
   - `memoryview`
   - `array.array`
-  - `numpy.ndarray`
+  - ``numpy.ndarray``
 """

--- a/src/circuitpython_typing.py
+++ b/src/circuitpython_typing.py
@@ -38,7 +38,7 @@ ReadableBuffer = Union[bytes, bytearray, memoryview, array, ndarray]
   - `bytearray`
   - `memoryview`
   - `array.array`
-  - `ndarray`
+  - `numpy.ndarray`
 """
 
 WriteableBuffer = Union[bytearray, memoryview, array, ndarray]
@@ -46,5 +46,5 @@ WriteableBuffer = Union[bytearray, memoryview, array, ndarray]
   - `bytearray`
   - `memoryview`
   - `array.array`
-  - `ndarray`
+  - `numpy.ndarray`
 """

--- a/src/circuitpython_typing.py
+++ b/src/circuitpython_typing.py
@@ -23,7 +23,7 @@
 `circuitpython_typing` - Define subset of types for C-level protocols
 =====================================================================
 
-See `CircuitPython:board` in CircuitPython for more details.
+See `CircuitPython:circuit_python` in CircuitPython for more details.
 
 * Author(s): Alec Delaney
 """

--- a/src/circuitpython_typing.py
+++ b/src/circuitpython_typing.py
@@ -32,9 +32,7 @@ from typing import Union
 from array import array
 from numpy import ndarray
 
-ReadableBuffer = Union[
-    bytes, bytearray, memoryview, array, ndarray
-]
+ReadableBuffer = Union[bytes, bytearray, memoryview, array, ndarray]
 """Classes that implement the readable buffer protocol
   - `bytes`
   - `bytearray`
@@ -43,9 +41,7 @@ ReadableBuffer = Union[
   - `numpy.ndarray`
 """
 
-WriteableBuffer = Union[
-    bytearray, memoryview, array, ndarray
-]
+WriteableBuffer = Union[bytearray, memoryview, array, ndarray]
 """Classes that implement the writeable buffer protocol
   - `bytearray`
   - `memoryview`

--- a/src/circuitpython_typing.py
+++ b/src/circuitpython_typing.py
@@ -1,0 +1,54 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2017 cefn for adafruit industries
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+"""
+`circuitpython_typing` - Define subset of types for C-level protocols
+======================================================
+
+See `CircuitPython:board` in CircuitPython for more details.
+
+* Author(s): Alec Delaney
+"""
+
+from typing import Union
+from array import array
+from numpy import ndarray
+
+ReadableBuffer = Union[
+    bytes, bytearray, memoryview, array, ndarray
+]
+"""Classes that implement the readable buffer protocol
+  - `bytes`
+  - `bytearray`
+  - `memoryview`
+  - `array.array`
+  - `numpy.ndarray`
+"""
+
+WriteableBuffer = Union[
+    bytearray, memoryview, array, ndarray
+]
+"""Classes that implement the writeable buffer protocol
+  - `bytearray`
+  - `memoryview`
+  - `array.array`
+  - `numpy.ndarray`
+"""

--- a/src/circuitpython_typing.py
+++ b/src/circuitpython_typing.py
@@ -23,7 +23,7 @@
 `circuitpython_typing` - Define subset of types for C-level protocols
 =====================================================================
 
-See `CircuitPython:circuit_python` in CircuitPython for more details.
+See `CircuitPython:circuitpython_typing` in CircuitPython for more details.
 
 * Author(s): Alec Delaney
 """

--- a/src/circuitpython_typing.py
+++ b/src/circuitpython_typing.py
@@ -21,7 +21,7 @@
 # THE SOFTWARE.
 """
 `circuitpython_typing` - Define subset of types for C-level protocols
-======================================================
+=====================================================================
 
 See `CircuitPython:board` in CircuitPython for more details.
 

--- a/src/circuitpython_typing.py
+++ b/src/circuitpython_typing.py
@@ -38,7 +38,7 @@ ReadableBuffer = Union[bytes, bytearray, memoryview, array, ndarray]
   - `bytearray`
   - `memoryview`
   - `array.array`
-  - `numpy.ndarray`
+  - `ndarray`
 """
 
 WriteableBuffer = Union[bytearray, memoryview, array, ndarray]
@@ -46,5 +46,5 @@ WriteableBuffer = Union[bytearray, memoryview, array, ndarray]
   - `bytearray`
   - `memoryview`
   - `array.array`
-  - `numpy.ndarray`
+  - `ndarray`
 """


### PR DESCRIPTION
Address inability to use CircuitPython's typing module `_typing` (which will become `circuitpython_typing`) by adding a subset of the module.  In CircuitPython these are stub files, as my understanding is that these are purely conceptual (`bytearray` of course is a real thing, but a `ReabableBuffer` isn't and is just a way of communicating things that implement the buffer reading protocol).

This will works for CircuitPython, because adding the too the `try`/`except` block were using for typing in libraries means that it will never actually try to import the library, while the computer environment used to write code **will** be able to and will access the stubs.  However, since the `try`/`block` is intended to fail by importing the CPython `typing` library, platforms running Blinka won't actually fail, so my understanding is that these must be actual modules (`.py` instead of `.pyi`).

The only subsets of the CircuitPython typing modules implemented here are ones that could actually be used within an environment running Blinka, so they either have CPython implementations or CPython equivalents.  The latter translates to allowing the libraries that CircuitPython was previously emulating (e.g. - allowing the actual CPython `array.array` library and NumPy's `numpy.ndarray` that `ulab.numpy.array` was emulating).

It's worth mentioning that the latter example of import a NumPy class for typing may eat up memory that never actually gets used functionally in code, so it's worth asking if it's worth doing so for the sake of completeness.  But I also don't know too much about typical Blinka use so I don't know how catastrophic this is.

Happy to make changes as needed!

Here's how CircuitPython defines the typings:
https://github.com/adafruit/circuitpython/blob/main/shared-bindings/circuitpython_typing/__init__.pyi