### PR TITLE
Typing Library Documentation Touchups

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,10 +20,12 @@ Introduction
 This repository contains a selection of packages emulating the CircuitPython API
 for devices or hosts running CPython or MicroPython. Working code exists to emulate these CircuitPython packages:
 
+* **_typing** - (Legacy) subset of types for C-level protocols
 * **analogio** - analog input/output pins, using pin identities from board+microcontroller packages
 * **bitbangio** - software-driven interfaces for I2C, SPI
 * **board** - breakout-specific pin identities
 * **busio** - hardware-driven interfaces for I2C, SPI, UART
+* **circuitpython_typing** - Subset of types for C-level protocols
 * **digitalio** - digital input/output pins, using pin identities from board+microcontroller packages
 * **keypad** - support for scanning keys and key matrices
 * **microcontroller** - chip-specific pin identities

--- a/src/_typing.py
+++ b/src/_typing.py
@@ -23,9 +23,9 @@
 `_typing` - Define (legacy) subset of types for C-level protocols
 =================================================================
 
-See `CircuitPython:circuitpython_typing` in CircuitPython for more details.
-
 * Author(s): Alec Delaney
+
+See `CircuitPython:circuitpython_typing` in CircuitPython for more details.
 """
 
 from circuitpython_typing import *  # pylint: disable=wildcard-import,unused-wildcard-import

--- a/src/circuitpython_typing.py
+++ b/src/circuitpython_typing.py
@@ -34,17 +34,19 @@ from numpy import ndarray
 
 ReadableBuffer = Union[bytes, bytearray, memoryview, array, ndarray]
 """Classes that implement the readable buffer protocol
-  - `bytes`
-  - `bytearray`
-  - `memoryview`
-  - `array.array`
-  - ``numpy.ndarray``
+
+  * `bytes`
+  * `bytearray`
+  * `memoryview`
+  * `array.array`
+  * ``numpy.ndarray``
 """
 
 WriteableBuffer = Union[bytearray, memoryview, array, ndarray]
 """Classes that implement the writeable buffer protocol
-  - `bytearray`
-  - `memoryview`
-  - `array.array`
-  - ``numpy.ndarray``
+
+  * `bytearray`
+  * `memoryview`
+  * `array.array`
+  * ``numpy.ndarray``
 """


### PR DESCRIPTION
Companion PR of #543!

1. Adds typing libraries to README so they show up in repo and documentation landing
2. Swap author and note so it doesn't look like something is missing if you go to the `_typing` documentation
3. Fix bullet point list that isn't showing properly currently