### PR TITLE
Remove numpy import

### DIFF
--- a/src/circuitpython_typing.py
+++ b/src/circuitpython_typing.py
@@ -30,7 +30,6 @@ See `CircuitPython:circuitpython_typing` in CircuitPython for more details.
 
 from typing import Union
 from array import array
-from numpy import ndarray
 
 ReadableBuffer = Union[bytes, bytearray, memoryview, array, ndarray]
 """Classes that implement the readable buffer protocol
@@ -39,7 +38,6 @@ ReadableBuffer = Union[bytes, bytearray, memoryview, array, ndarray]
   * `bytearray`
   * `memoryview`
   * `array.array`
-  * ``numpy.ndarray``
 """
 
 WriteableBuffer = Union[bytearray, memoryview, array, ndarray]
@@ -48,5 +46,4 @@ WriteableBuffer = Union[bytearray, memoryview, array, ndarray]
   * `bytearray`
   * `memoryview`
   * `array.array`
-  * ``numpy.ndarray``
 """

--- a/src/circuitpython_typing.py
+++ b/src/circuitpython_typing.py
@@ -31,7 +31,7 @@ See `CircuitPython:circuitpython_typing` in CircuitPython for more details.
 from typing import Union
 from array import array
 
-ReadableBuffer = Union[bytes, bytearray, memoryview, array, ndarray]
+ReadableBuffer = Union[bytes, bytearray, memoryview, array]
 """Classes that implement the readable buffer protocol
 
   * `bytes`
@@ -40,7 +40,7 @@ ReadableBuffer = Union[bytes, bytearray, memoryview, array, ndarray]
   * `array.array`
 """
 
-WriteableBuffer = Union[bytearray, memoryview, array, ndarray]
+WriteableBuffer = Union[bytearray, memoryview, array]
 """Classes that implement the writeable buffer protocol
 
   * `bytearray`


### PR DESCRIPTION
Hotfixes issues with `adafruit_bus_device` and other libraries that are importing `circuitpython_typing` on Blinka platforms!