### PR TITLE
Update colorwheel

### DIFF
--- a/src/rainbowio.py
+++ b/src/rainbowio.py
@@ -4,7 +4,7 @@
 See `CircuitPython:rainbowio` in CircuitPython for more details.
 Not supported by all boards.
 
-* Author(s): Kattni Rembor
+* Author(s): Kattni Rembor, Carter Nelson
 """
 
 
@@ -16,12 +16,23 @@ def colorwheel(color_value):
     :param int color_value: 0-255 of color value to return
     :return: tuple of RGB values
     """
+    color_value = int(color_value)
     if color_value < 0 or color_value > 255:
-        return 0, 0, 0
-    if color_value < 85:
-        return 255 - color_value * 3, color_value * 3, 0
-    if color_value < 170:
+        r = 0
+        g = 0
+        b = 0
+    elif color_value < 85:
+        r = int(255 - color_value * 3)
+        g = int(color_value * 3)
+        b = 0
+    elif color_value < 170:
         color_value -= 85
-        return 0, 255 - color_value * 3, color_value * 3
-    color_value -= 170
-    return color_value * 3, 0, 255 - color_value * 3
+        r = 0
+        g = int(255 - color_value * 3)
+        b = int(color_value * 3)
+    else:
+        color_value -= 170
+        r = int(color_value * 3)
+        g = 0
+        b = int(255 - color_value * 3)
+    return r << 16 | g << 8 | b


### PR DESCRIPTION
For #514. Just ran into this myself so worked up a fix. Return is now changed to 24 bit value `0xRRGGBB`.

CircuitPython API for ref:
https://docs.circuitpython.org/en/latest/shared-bindings/rainbowio/index.html#rainbowio.colorwheel

**BEFORE**
```python
(blinka) pi@raspberrypi:~ $ python3
Python 3.9.2 (default, Mar 12 2021, 04:06:34) 
[GCC 10.2.1 20210110] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from rainbowio import colorwheel
>>> colorwheel(123.45)
(0, 139.64999999999998, 115.35000000000001)
>>> colorwheel(123)
(0, 141, 114)
>>> 
```


**AFTER**
```python
(blinka) pi@raspberrypi:~ $ python3
Python 3.9.2 (default, Mar 12 2021, 04:06:34) 
[GCC 10.2.1 20210110] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from rainbowio import colorwheel
>>> colorwheel(123.45)
36210
>>> colorwheel(123)
36210
>>> print("0x{:06x}".format(colorwheel(0)))
0xff0000
>>> print("0x{:06x}".format(colorwheel(255)))
0xff0000
>>> print("0x{:06x}".format(colorwheel(85)))
0x00ff00
>>> print("0x{:06x}".format(colorwheel(170)))
0x0000ff
>>>
```
