### PR TITLE
Allow older and newer versions of libgpiod to work, Allow Pullups

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@
 
 repos:
 -   repo: https://github.com/python/black
-    rev: 22.1.0
+    rev: 22.3.0
     hooks:
     - id: black
       additional_dependencies: ['click==8.0.4']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,9 +4,10 @@
 
 repos:
 -   repo: https://github.com/python/black
-    rev: 20.8b1
+    rev: 22.1.0
     hooks:
     - id: black
+      additional_dependencies: ['click==8.0.4']
 -   repo: https://github.com/fsfe/reuse-tool
     rev: v0.12.1
     hooks:

--- a/src/adafruit_blinka/microcontroller/generic_linux/libgpiod_pin.py
+++ b/src/adafruit_blinka/microcontroller/generic_linux/libgpiod_pin.py
@@ -10,7 +10,6 @@ except ImportError:
         "https://github.com/adafruit/Raspberry-Pi-Installer-Scripts/blob/master/libgpiod.sh"
     ) from ImportError
 
-
 class Pin:
     """Pins dont exist in CPython so...lets make our own!"""
 
@@ -31,10 +30,16 @@ class Pin:
         self.id = pin_id
         if isinstance(pin_id, tuple):
             self._num = int(pin_id[1])
-            self._chip = gpiod.Chip(str(pin_id[0]), gpiod.Chip.OPEN_BY_NUMBER)
+            if hasattr(gpiod, 'Chip'):
+                self._chip = gpiod.Chip(str(pin_id[0]), gpiod.Chip.OPEN_BY_NUMBER)
+            else:
+                self._chip = gpiod.chip(str(pin_id[0]), gpiod.chip.OPEN_BY_NUMBER)
         else:
             self._num = int(pin_id)
-            self._chip = gpiod.Chip("gpiochip0", gpiod.Chip.OPEN_BY_NAME)
+            if hasattr(gpiod, 'Chip'):
+                self._chip = gpiod.Chip("gpiochip0", gpiod.Chip.OPEN_BY_NAME)
+            else:
+                self._chip = gpiod.chip("gpiochip0", gpiod.chip.OPEN_BY_NAME)
         self._line = None
 
     def __repr__(self):
@@ -52,32 +57,66 @@ class Pin:
         if mode is not None:
             if mode == self.IN:
                 flags = 0
+                self._line.release()
                 if pull is not None:
                     if pull == self.PULL_UP:
-                        raise NotImplementedError(
-                            "Internal pullups not supported in libgpiod, "
-                            "use physical resistor instead!"
-                        )
-                    if pull == self.PULL_DOWN:
-                        raise NotImplementedError(
-                            "Internal pulldowns not supported in libgpiod, "
-                            "use physical resistor instead!"
-                        )
-                    raise RuntimeError("Invalid pull for pin: %s" % self.id)
+                        if hasattr(gpiod, 'line') and hasattr(gpiod.line, 'BIAS_PULL_UP') :
+                            config = gpiod.line_request()
+                            config.consumer = self._CONSUMER
+                            config.request_type = gpiod.line.BIAS_PULL_UP
+                            self._line.request(config)
+                        else:
+                            self._line.request(
+                                consumer=self._CONSUMER, type=gpiod.LINE_REQ_DIR_IN, flags=flags
+                            )
+                            raise NotImplementedError(
+                                "Internal pullups not supported in this version of libgpiod, "
+                                "use physical resistor instead!"
+                            )
+                    elif pull == self.PULL_DOWN:
+                        if hasattr(gpiod, 'line') and hasattr(gpiod.line, 'BIAS_PULL_DOWN') :
+                            config = gpiod.line_request()
+                            config.consumer = self._CONSUMER
+                            config.request_type = gpiod.line.BIAS_PULL_DOWN
+                            self._line.request(config)                     
+                        else:
+                            raise NotImplementedError(
+                                "Internal pulldowns not supported in this version of libgpiod, "
+                                "use physical resistor instead!"
+                            )
+                    elif pull == self.PULL_NONE:
+                        if hasattr(gpiod, 'line') and hasattr(gpiod.line, 'BIAS_DISABLE') :
+                            config = gpiod.line_request()
+                            config.consumer = self._CONSUMER
+                            config.request_type = gpiod.line.BIAS_DISABLE
+                            self._line.request(config)
+                    else:
+                        raise RuntimeError(f"Invalid pull for pin: {self.id}")
 
                 self._mode = self.IN
                 self._line.release()
-                self._line.request(
-                    consumer=self._CONSUMER, type=gpiod.LINE_REQ_DIR_IN, flags=flags
-                )
+                if hasattr(gpiod, 'LINE_REQ_DIR_IN'):
+                    self._line.request(
+                        consumer=self._CONSUMER, type=gpiod.LINE_REQ_DIR_IN, flags=flags
+                    )
+                else:
+                    config = gpiod.line_request()
+                    config.consumer = self._CONSUMER
+                    config.request_type = gpiod.line_request.DIRECTION_INPUT
+                    self._line.request(config)
 
             elif mode == self.OUT:
                 if pull is not None:
                     raise RuntimeError("Cannot set pull resistor on output")
                 self._mode = self.OUT
                 self._line.release()
-                self._line.request(consumer=self._CONSUMER, type=gpiod.LINE_REQ_DIR_OUT)
-
+                if hasattr(gpiod, 'LINE_REQ_DIR_OUT'):
+                    self._line.request(consumer=self._CONSUMER, type=gpiod.LINE_REQ_DIR_OUT)
+                else:
+                    config = gpiod.line_request()
+                    config.consumer = self._CONSUMER
+                    config.request_type = gpiod.line_request.DIRECTION_OUTPUT
+                    self._line.request(config)
             else:
                 raise RuntimeError("Invalid mode for pin: %s" % self.id)
 

--- a/src/adafruit_blinka/microcontroller/generic_linux/libgpiod_pin.py
+++ b/src/adafruit_blinka/microcontroller/generic_linux/libgpiod_pin.py
@@ -10,6 +10,7 @@ except ImportError:
         "https://github.com/adafruit/Raspberry-Pi-Installer-Scripts/blob/master/libgpiod.sh"
     ) from ImportError
 
+# pylint: disable=too-many-branches,too-many-statements
 class Pin:
     """Pins dont exist in CPython so...lets make our own!"""
 
@@ -30,13 +31,13 @@ class Pin:
         self.id = pin_id
         if isinstance(pin_id, tuple):
             self._num = int(pin_id[1])
-            if hasattr(gpiod, 'Chip'):
+            if hasattr(gpiod, "Chip"):
                 self._chip = gpiod.Chip(str(pin_id[0]), gpiod.Chip.OPEN_BY_NUMBER)
             else:
                 self._chip = gpiod.chip(str(pin_id[0]), gpiod.chip.OPEN_BY_NUMBER)
         else:
             self._num = int(pin_id)
-            if hasattr(gpiod, 'Chip'):
+            if hasattr(gpiod, "Chip"):
                 self._chip = gpiod.Chip("gpiochip0", gpiod.Chip.OPEN_BY_NAME)
             else:
                 self._chip = gpiod.chip("gpiochip0", gpiod.chip.OPEN_BY_NAME)
@@ -60,32 +61,40 @@ class Pin:
                 self._line.release()
                 if pull is not None:
                     if pull == self.PULL_UP:
-                        if hasattr(gpiod, 'line') and hasattr(gpiod.line, 'BIAS_PULL_UP') :
+                        if hasattr(gpiod, "line") and hasattr(
+                            gpiod.line, "BIAS_PULL_UP"
+                        ):
                             config = gpiod.line_request()
                             config.consumer = self._CONSUMER
                             config.request_type = gpiod.line.BIAS_PULL_UP
                             self._line.request(config)
                         else:
                             self._line.request(
-                                consumer=self._CONSUMER, type=gpiod.LINE_REQ_DIR_IN, flags=flags
+                                consumer=self._CONSUMER,
+                                type=gpiod.LINE_REQ_DIR_IN,
+                                flags=flags,
                             )
                             raise NotImplementedError(
                                 "Internal pullups not supported in this version of libgpiod, "
                                 "use physical resistor instead!"
                             )
                     elif pull == self.PULL_DOWN:
-                        if hasattr(gpiod, 'line') and hasattr(gpiod.line, 'BIAS_PULL_DOWN') :
+                        if hasattr(gpiod, "line") and hasattr(
+                            gpiod.line, "BIAS_PULL_DOWN"
+                        ):
                             config = gpiod.line_request()
                             config.consumer = self._CONSUMER
                             config.request_type = gpiod.line.BIAS_PULL_DOWN
-                            self._line.request(config)                     
+                            self._line.request(config)
                         else:
                             raise NotImplementedError(
                                 "Internal pulldowns not supported in this version of libgpiod, "
                                 "use physical resistor instead!"
                             )
                     elif pull == self.PULL_NONE:
-                        if hasattr(gpiod, 'line') and hasattr(gpiod.line, 'BIAS_DISABLE') :
+                        if hasattr(gpiod, "line") and hasattr(
+                            gpiod.line, "BIAS_DISABLE"
+                        ):
                             config = gpiod.line_request()
                             config.consumer = self._CONSUMER
                             config.request_type = gpiod.line.BIAS_DISABLE
@@ -95,7 +104,7 @@ class Pin:
 
                 self._mode = self.IN
                 self._line.release()
-                if hasattr(gpiod, 'LINE_REQ_DIR_IN'):
+                if hasattr(gpiod, "LINE_REQ_DIR_IN"):
                     self._line.request(
                         consumer=self._CONSUMER, type=gpiod.LINE_REQ_DIR_IN, flags=flags
                     )
@@ -110,8 +119,10 @@ class Pin:
                     raise RuntimeError("Cannot set pull resistor on output")
                 self._mode = self.OUT
                 self._line.release()
-                if hasattr(gpiod, 'LINE_REQ_DIR_OUT'):
-                    self._line.request(consumer=self._CONSUMER, type=gpiod.LINE_REQ_DIR_OUT)
+                if hasattr(gpiod, "LINE_REQ_DIR_OUT"):
+                    self._line.request(
+                        consumer=self._CONSUMER, type=gpiod.LINE_REQ_DIR_OUT
+                    )
                 else:
                     config = gpiod.line_request()
                     config.consumer = self._CONSUMER

--- a/test/src/testing/universal/i2c.py
+++ b/test/src/testing/universal/i2c.py
@@ -69,7 +69,7 @@ class TestMMA8451Interactive(TestCase):
         sensor = adafruit_mma8451.MMA8451(i2c)
 
         x, y, z = sensor.acceleration
-        absolute = math.sqrt(x ** 2 + y ** 2 + z ** 2)
+        absolute = math.sqrt(x**2 + y**2 + z**2)
         self.assertTrue(9 <= absolute <= 11, "Not earth gravity")
 
         orientation = sensor.orientation


### PR DESCRIPTION
Fixes #571. Fixes #425. Tested on Odroid C2 with older and newer libgpiod.