### PR TITLE
Close HID connnection to MCP2221 when resetting

### DIFF
--- a/src/adafruit_blinka/microcontroller/mcp2221/mcp2221.py
+++ b/src/adafruit_blinka/microcontroller/mcp2221/mcp2221.py
@@ -133,6 +133,7 @@ class MCP2221:
 
     def _reset(self):
         self._hid_xfer(b"\x70\xAB\xCD\xEF", response=False)
+        self._hid.close()
         time.sleep(MCP2221_RESET_DELAY)
         start = time.monotonic()
         while time.monotonic() - start < 5:

--- a/src/adafruit_blinka/microcontroller/rp2040_u2if/rp2040_u2if.py
+++ b/src/adafruit_blinka/microcontroller/rp2040_u2if/rp2040_u2if.py
@@ -94,6 +94,7 @@ class RP2040_u2if:
 
     def _reset(self):
         self._hid_xfer(bytes([self.SYS_RESET]), False)
+        self._hid.close()
         time.sleep(RP2040_U2IF_RESET_DELAY)
         start = time.monotonic()
         while time.monotonic() - start < 5:


### PR DESCRIPTION
Fix for #573.

Pretty simple, just need to explicitly close when resetting. Tested locally to recreate original issue and verify this patch worked to fix. Even blinked an LED to make sure.