### PR TITLE
Allow Blinka to run on non-embedded environments

### DIFF
--- a/src/microcontroller/__init__.py
+++ b/src/microcontroller/__init__.py
@@ -119,7 +119,7 @@ elif chip_id == ap_chip.RP2040_U2IF:
 elif chip_id == ap_chip.GENERIC_X86:
     print("WARNING: GENERIC_X86 is not fully supported. Some features may not work.")
 elif chip_id == None:
-    print("WARNING [__init__.py]: chip_id is None!")
+    print("WARNING: chip_id == None is not fully supported. Some features may not work.")
 elif "sphinx" in sys.modules:
     pass
 else:

--- a/src/microcontroller/__init__.py
+++ b/src/microcontroller/__init__.py
@@ -118,6 +118,8 @@ elif chip_id == ap_chip.RP2040_U2IF:
     from adafruit_blinka.microcontroller.rp2040_u2if import *
 elif chip_id == ap_chip.GENERIC_X86:
     print("WARNING: GENERIC_X86 is not fully supported. Some features may not work.")
+elif chip_id == None:
+    print("WARNING [__init__.py]: chip_id is None!")
 elif "sphinx" in sys.modules:
     pass
 else:

--- a/src/microcontroller/__init__.py
+++ b/src/microcontroller/__init__.py
@@ -119,7 +119,9 @@ elif chip_id == ap_chip.RP2040_U2IF:
 elif chip_id == ap_chip.GENERIC_X86:
     print("WARNING: GENERIC_X86 is not fully supported. Some features may not work.")
 elif chip_id is None:
-    print("WARNING: chip_id == None is not fully supported. Some features may not work.")
+    print(
+        "WARNING: chip_id == None is not fully supported. Some features may not work."
+    )
 elif "sphinx" in sys.modules:
     pass
 else:

--- a/src/microcontroller/__init__.py
+++ b/src/microcontroller/__init__.py
@@ -118,7 +118,7 @@ elif chip_id == ap_chip.RP2040_U2IF:
     from adafruit_blinka.microcontroller.rp2040_u2if import *
 elif chip_id == ap_chip.GENERIC_X86:
     print("WARNING: GENERIC_X86 is not fully supported. Some features may not work.")
-elif chip_id == None:
+elif chip_id is None:
     print("WARNING: chip_id == None is not fully supported. Some features may not work.")
 elif "sphinx" in sys.modules:
     pass

--- a/src/microcontroller/pin.py
+++ b/src/microcontroller/pin.py
@@ -103,7 +103,9 @@ elif "sphinx" in sys.modules:
     # pylint: disable=unused-import
     from adafruit_blinka.microcontroller.generic_micropython import Pin
 elif chip_id is None:
-    print("WARNING: chip_id == None is not fully supported. Some features may not work.")
+    print(
+        "WARNING: chip_id == None is not fully supported. Some features may not work."
+    )
     from adafruit_blinka.microcontroller.generic_micropython import Pin
 else:
     raise NotImplementedError("Microcontroller not supported: ", chip_id)

--- a/src/microcontroller/pin.py
+++ b/src/microcontroller/pin.py
@@ -102,6 +102,9 @@ elif chip_id == ap_chip.RP2040_U2IF:
 elif "sphinx" in sys.modules:
     # pylint: disable=unused-import
     from adafruit_blinka.microcontroller.generic_micropython import Pin
+elif chip_id == ap_chip.GENERIC_X86:
+    print("WARNING: GENERIC_X86 is not fully supported. Some features may not work.")
+    from adafruit_blinka.microcontroller.generic_micropython import Pin
 elif chip_id is None:
     print(
         "WARNING: chip_id == None is not fully supported. Some features may not work."

--- a/src/microcontroller/pin.py
+++ b/src/microcontroller/pin.py
@@ -103,7 +103,7 @@ elif "sphinx" in sys.modules:
     # pylint: disable=unused-import
     from adafruit_blinka.microcontroller.generic_micropython import Pin
 elif chip_id == None:
-    print("WARNING [pin.py]: chip_id is None!")
-    from adafruit_blinka.microcontroller.rp2040.pin import *
+    print("WARNING: chip_id == None is not fully supported. Some features may not work.")
+    from adafruit_blinka.microcontroller.generic_micropython import Pin
 else:
     raise NotImplementedError("Microcontroller not supported: ", chip_id)

--- a/src/microcontroller/pin.py
+++ b/src/microcontroller/pin.py
@@ -102,5 +102,8 @@ elif chip_id == ap_chip.RP2040_U2IF:
 elif "sphinx" in sys.modules:
     # pylint: disable=unused-import
     from adafruit_blinka.microcontroller.generic_micropython import Pin
+elif chip_id == None:
+    print("WARNING [pin.py]: chip_id is None!")
+    from adafruit_blinka.microcontroller.rp2040.pin import *
 else:
     raise NotImplementedError("Microcontroller not supported: ", chip_id)

--- a/src/microcontroller/pin.py
+++ b/src/microcontroller/pin.py
@@ -102,7 +102,7 @@ elif chip_id == ap_chip.RP2040_U2IF:
 elif "sphinx" in sys.modules:
     # pylint: disable=unused-import
     from adafruit_blinka.microcontroller.generic_micropython import Pin
-elif chip_id == None:
+elif chip_id is None:
     print("WARNING: chip_id == None is not fully supported. Some features may not work.")
     from adafruit_blinka.microcontroller.generic_micropython import Pin
 else:


### PR DESCRIPTION
This PR allows blinka to run on non-embedded systems, i.e. GENERIC_LINUX or Windows Environments. The motivation was to allow the use of the displayio library on non-circuitpython boards. (See https://github.com/adafruit/Adafruit_Blinka_Displayio/pull/63 for a discussion about this use-case). This allows the library to be used to create general-purpose desktop GUIs, as well as to simulate a hardware display so that embedded GUIs can be developed and tested without physical hardware.

Instead of failing with a `NotImplementedError` if the platform's `chip_id` is `None` or `'GENERIC_X86'`, I print a warning message. In order to satisfy the `Pin` import in `pin.py`, I imported the class from `generic_micropython`. This might not be the best thing to do here, since the platform is not necessarily micropython -- I'm open to suggestions about how to make this more semantically accurate.