### PR TITLE
Require adafruit-circuitpython-typing on install

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ sysv_ipc>=1.1.0; sys_platform == 'linux' and platform_machine!='mips'
 pyftdi>=0.40.0
 binho-host-adapter>=0.1.6
 numpy>=1.21.5
+adafruit-circuitpython-typing

--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,7 @@ setup(
         "Adafruit-PlatformDetect>=3.13.0",
         "Adafruit-PureIO>=1.1.7",
         "pyftdi>=0.40.0",
+        "adafruit-circuitpython-typing",
     ]
     + board_reqs,
     license="MIT",


### PR DESCRIPTION
Fixes #580 by adding `adafruit-circuitpython-typing` to `setup.py` and `requirements.txt`.  I don't think a specific version is needed, and the few libraries that require features that weren't in base (really anything other than `ReadableBuffer` and `WriteableBuffer`) and had them added to that library will have to call those out and pin to minimum versions anyway.