### PR TITLE
Add support for Radxa Zero - S905Y2

### DIFF
--- a/src/adafruit_blinka/board/radxa/radxazero.py
+++ b/src/adafruit_blinka/board/radxa/radxazero.py
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: 2021 Melissa LeBlanc-Williams for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+"""Pin definitions for the Radxa Zero."""
+
+from adafruit_blinka.microcontroller.amlogic.s905y2 import pin
+
+D3 = pin.GPIOA_14
+D5 = pin.GPIOA_15
+D7 = pin.GPIOAO_3
+D8 = pin.GPIOAO_8
+D10 = pin.GPIOAO_1
+D11 = pin.GPIOAO_2
+D12 = pin.GPIOX_9
+D13 = pin.GPIOX_11
+D16 = pin.GPIOX_10
+D18 = pin.GPIOX_8
+D19 = pin.GPIOH_4
+D21 = pin.GPIOH_5
+D23 = pin.GPIOH_7
+D24 = pin.GPIOH_6
+D27 = pin.GPIOAO_3
+D28 = pin.GPIOAO_2
+D32 = pin.GPIOAO_4
+D35 = pin.GPIOAO_8
+D36 = pin.GPIOH_8
+D37 = pin.GPIOAO_9
+D38 = pin.GPIOAO_10
+D40 = pin.GPIOAO_11
+
+SDA1 = D24
+SCL1 = D23
+
+SDA3 = D3
+SCL3 = D5
+
+SDA4 = D27
+SCL4 = D28
+
+SCLK = D13
+MOSI = D18
+MISO = D12
+
+SCLK1 = D23
+MOSI1 = D19
+MISO1 = D21
+
+UART_TX = D11
+UART_RX = D7
+
+UART_TX1 = D18
+UART_RX1 = D12
+
+UART_TX4 = D23
+UART_RX4 = D24

--- a/src/adafruit_blinka/microcontroller/amlogic/s905y2/pin.py
+++ b/src/adafruit_blinka/microcontroller/amlogic/s905y2/pin.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: 2021 Melissa LeBlanc-Williams for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+"""AmLogic s905y2 pin names"""
+# pylint: disable=wildcard-import,unused-wildcard-import
+from adafruit_blinka.microcontroller.generic_linux.libgpiod_pin import Pin
+
+periphs = 0
+aobus = 1
+
+GPIO412 = GPIOAO_0 = Pin((aobus, 0))
+GPIO413 = GPIOAO_1 = Pin((aobus, 1))
+GPIO414 = GPIOAO_2 = Pin((aobus, 2))
+GPIO415 = GPIOAO_3 = Pin((aobus, 3))
+GPIO416 = GPIOAO_4 = Pin((aobus, 4))
+
+GPIO420 = GPIOAO_8 = Pin((aobus, 8))
+GPIO421 = GPIOAO_9 = Pin((aobus, 9))
+GPIO422 = GPIOAO_10 = Pin((aobus, 10))
+GPIO423 = GPIOAO_11 = Pin((aobus, 11))
+
+GPIO447 = GPIOH_4 = Pin((periphs, 20))
+GPIO448 = GPIOH_5 = Pin((periphs, 21))
+GPIO449 = GPIOH_6 = Pin((periphs, 22))
+GPIO450 = GPIOH_7 = Pin((periphs, 23))
+GPIO451 = GPIOH_8 = Pin((periphs, 24))
+
+GPIO490 = GPIOA_14 = Pin((periphs, 63))
+GPIO491 = GPIOA_15 = Pin((periphs, 64))
+
+
+GPIO500 = GPIOX_8 = Pin((periphs, 73))
+GPIO501 = GPIOX_9 = Pin((periphs, 74))
+GPIO502 = GPIOX_10 = Pin((periphs, 75))
+GPIO503 = GPIOX_11 = Pin((periphs, 76))
+
+
+I2C1_SDA = GPIOH_6
+I2C1_SCL = GPIOH_7
+I2C3_SDA = GPIOA_14
+I2C3_SCL = GPIOA_15
+I2C4_SDA = GPIOAO_3
+I2C4_SCL = GPIOAO_2
+
+SPIA_SCLK = GPIOX_11
+SPIA_MISO = GPIOX_9
+SPIA_MOSI = GPIOX_8
+
+SPIB_SCLK = GPIOH_7
+SPIB_MISO = GPIOH_5
+SPIB_MOSI = GPIOH_4
+
+UARTA_TX = GPIOAO_2
+UARTA_RX = GPIOAO_3
+UARTB_TX = GPIOAO_8
+UARTB_RX = GPIOAO_9
+UARTC_TX = GPIOH_7
+UARTC_RX = GPIOH_6
+
+i2cPorts = (
+    (1, I2C1_SCL, I2C1_SDA),
+    (3, I2C3_SCL, I2C3_SDA),
+    (4, I2C4_SCL, I2C4_SDA),
+)
+
+spiPorts = (
+    (0, SPIA_SCLK, SPIA_MOSI, SPIA_MISO),
+    (1, SPIB_SCLK, SPIB_MOSI, SPIB_MISO),
+)
+
+uartPorts = (
+    (0, UARTA_TX, UARTA_RX),
+    (1, UARTB_TX, UARTB_RX),
+    (4, UARTC_TX, UARTC_RX),
+)

--- a/src/board.py
+++ b/src/board.py
@@ -205,6 +205,9 @@ elif board_id == ap_board.CLOCKWORK_CPI3:
 elif board_id == ap_board.ONION_OMEGA2:
     from adafruit_blinka.board.onion.omega2 import *
 
+elif board_id == ap_board.RADXA_ZERO:
+    from adafruit_blinka.board.radxa.radxazero import *
+
 elif board_id == ap_board.ROCK_PI_S:
     from adafruit_blinka.board.radxa.rockpis import *
 

--- a/src/digitalio.py
+++ b/src/digitalio.py
@@ -36,6 +36,8 @@ elif detector.chip.S905:
     from adafruit_blinka.microcontroller.amlogic.s905.pin import Pin
 elif detector.chip.S905X3:
     from adafruit_blinka.microcontroller.amlogic.s905x3.pin import Pin
+elif detector.chip.S905Y2:
+    from adafruit_blinka.microcontroller.amlogic.s905y2.pin import Pin
 elif detector.chip.S922X:
     from adafruit_blinka.microcontroller.amlogic.s922x.pin import Pin
 elif detector.chip.A311D:

--- a/src/microcontroller/__init__.py
+++ b/src/microcontroller/__init__.py
@@ -66,6 +66,8 @@ elif chip_id == ap_chip.S905:
     from adafruit_blinka.microcontroller.amlogic.s905 import *
 elif chip_id == ap_chip.S905X3:
     from adafruit_blinka.microcontroller.amlogic.s905x3 import *
+elif chip_id == ap_chip.S905Y2:
+    from adafruit_blinka.microcontroller.amlogic.s905y2 import *
 elif chip_id == ap_chip.S922X:
     from adafruit_blinka.microcontroller.amlogic.s922x import *
 elif chip_id == ap_chip.A311D:

--- a/src/microcontroller/pin.py
+++ b/src/microcontroller/pin.py
@@ -53,6 +53,8 @@ elif chip_id == ap_chip.S905:
     from adafruit_blinka.microcontroller.amlogic.s905.pin import *
 elif chip_id == ap_chip.S905X3:
     from adafruit_blinka.microcontroller.amlogic.s905x3.pin import *
+elif chip_id == ap_chip.S905Y2:
+    from adafruit_blinka.microcontroller.amlogic.s905y2.pin import *
 elif chip_id == ap_chip.S922X:
     from adafruit_blinka.microcontroller.amlogic.s922x.pin import *
 elif chip_id == ap_chip.A311D:


### PR DESCRIPTION
- Maps GPIO lines to GPIO numbers
- Define relevant constants for GPIO pins and protocols


[reference](https://wiki.radxa.com/Zero/hardware/gpio)
