### PR TITLE
Move (unimplemented) OneWire from busio to onewireio

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -40,6 +40,9 @@
 .. automodule:: neopixel_write
   :members:
 
+.. automodule:: onewireio
+  :members:
+
 .. automodule:: pulseio
   :members:
 

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,7 @@ setup(
         "keypad",
         "micropython",
         "neopixel_write",
+        "onewireio",
         "pulseio",
         "pwmio",
         "rainbowio",

--- a/src/busio.py
+++ b/src/busio.py
@@ -492,36 +492,3 @@ class UART(Lockable):
     def write(self, buf):
         """Write to the UART from a buffer"""
         return self._uart.write(buf)
-
-
-class OneWire:
-    """
-    Stub class for OneWire, which is currently not implemented
-    """
-
-    def __init__(self, pin):
-        raise NotImplementedError("OneWire has not been implemented")
-
-    def deinit(self):
-        """
-        Deinitialize the OneWire bus and release any hardware resources for reuse.
-        """
-        raise NotImplementedError("OneWire has not been implemented")
-
-    def reset(self):
-        """
-        Reset the OneWire bus and read presence
-        """
-        raise NotImplementedError("OneWire has not been implemented")
-
-    def read_bit(self):
-        """
-        Read in a bit
-        """
-        raise NotImplementedError("OneWire has not been implemented")
-
-    def write_bit(self, value):
-        """
-        Write out a bit based on value.
-        """
-        raise NotImplementedError("OneWire has not been implemented")

--- a/src/onewireio.py
+++ b/src/onewireio.py
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: 2021 Melissa LeBlanc-Williams for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+"""
+`onewireio` - 1-wire bus protocol
+=================================================
+
+See `CircuitPython:onewireio` in CircuitPython for more details.
+
+* Author(s): cefn
+"""
+
+# pylint: disable=import-outside-toplevel,too-many-branches,too-many-statements
+# pylint: disable=too-many-arguments,too-many-function-args,too-many-return-statements
+
+
+class OneWire:
+    """
+    Stub class for OneWire, which is currently not implemented
+    """
+
+    def __init__(self, pin):
+        raise NotImplementedError("OneWire has not been implemented")
+
+    def deinit(self):
+        """
+        Deinitialize the OneWire bus and release any hardware resources for reuse.
+        """
+        raise NotImplementedError("OneWire has not been implemented")
+
+    def reset(self):
+        """
+        Reset the OneWire bus and read presence
+        """
+        raise NotImplementedError("OneWire has not been implemented")
+
+    def read_bit(self):
+        """
+        Read in a bit
+        """
+        raise NotImplementedError("OneWire has not been implemented")
+
+    def write_bit(self, value):
+        """
+        Write out a bit based on value.
+        """
+        raise NotImplementedError("OneWire has not been implemented")


### PR DESCRIPTION
We have moved `OneWire` to its own module in CircuitPython, so we can easily turn it on and off

In CircuitPython 6.x.x, `OneWire` was available  as `busio.OneWire`.
In CircuitPython 7.x.x, `OneWire` is available as `busio.OneWire` _and_ as `onewireio.OneWire`.
In CircuitPython 8.x.x, `OneWire` will be available  only as `onewireio.OneWire`.

Have Blinka catch up to `onewireio.OneWire`. Note that `OneWire` is still unimplemented in Blinka

@makermelissa Do you want this to be a major version change? It's an API change, but for a piece of the API that's unimplemented. But integers are free.