### PR TITLE
Fix Raspberry Pi SPI bus 1 not working

### DIFF
--- a/src/adafruit_blinka/microcontroller/bcm2711/pin.py
+++ b/src/adafruit_blinka/microcontroller/bcm2711/pin.py
@@ -82,7 +82,7 @@ D45 = Pin(45)
 # ordered as spiId, sckId, mosiId, misoId
 spiPorts = (
     (0, SCLK, MOSI, MISO),
-    (6, SCLK_1, MOSI_1, MISO_1),
+    (1, SCLK_1, MOSI_1, MISO_1),
     (2, SCLK_2, MOSI_2, MISO_2),
     (3, D3, D2, D1),
     (4, D7, D6, D5),


### PR DESCRIPTION
The Raspberry Pi SPI bus 1 can't be used with the Blinka library. I suspect a simply typo.
With the supplied patch it works as expected. See also https://github.com/tinue/apa102-pi/issues/52
