### PR TITLE
Add typing information to micropython

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,8 @@ setup(
         "adafruit_blinka.microcontroller.bcm283x.pulseio": [
             "libgpiod_pulsein",
             "libgpiod_pulsein64",
-        ]
+        ],
+        "micropython": ["py.typed"],
     },
     install_requires=[
         "Adafruit-PlatformDetect>=3.13.0",

--- a/src/micropython/__init__.py
+++ b/src/micropython/__init__.py
@@ -8,22 +8,26 @@
 * Author(s): cefn
 """
 
+from typing import Callable, TypeVar, Any
 
-def const(x):
+Fun = TypeVar("Fun", bound=Callable[..., Any])
+
+
+def const(x: int) -> int:
     "Emulate making a constant"
     return x
 
 
-def native(f):
+def native(f: Fun) -> Fun:
     "Emulate making a native"
     return f
 
 
-def viper(f):
+def viper(f: Fun) -> None:
     "User is attempting to use a viper code emitter"
     raise SyntaxError("invalid micropython decorator")
 
 
-def asm_thumb(f):
+def asm_thumb(f: Fun) -> None:
     "User is attempting to use an inline assembler"
     raise SyntaxError("invalid micropython decorator")


### PR DESCRIPTION
This requires converting it into a package so that it can have a "py.typed" file.

After this, a package using micropython.const can be type checked