### PR TITLE
Provide stubs for micropython module in a more clearly compatible way

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
     python_requires=">=3.7.0",
     url="https://github.com/adafruit/Adafruit_Blinka",
     package_dir={"": "src"},
-    packages=find_packages("src"),
+    packages=find_packages("src") + ["micropython-stubs"],
     # py_modules lists top-level single file packages to include.
     # find_packages only finds packages in directories with __init__.py files.
     py_modules=[
@@ -74,8 +74,10 @@ setup(
         "adafruit_blinka.microcontroller.bcm283x.pulseio": [
             "libgpiod_pulsein",
             "libgpiod_pulsein64",
-        ]
+        ],
+        "micropython-stubs": ["*.pyi"],
     },
+    include_package_data=True,
     install_requires=[
         "Adafruit-PlatformDetect>=3.13.0",
         "Adafruit-PureIO>=1.1.7",

--- a/src/micropython-stubs/micropython.pyi
+++ b/src/micropython-stubs/micropython.pyi
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: 2021 Melissa LeBlanc-Williams for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+"""
+`micropython` - MicroPython Specific Decorator Functions
+========================================================
+
+* Author(s): cefn
+"""
+
+from typing import Callable, TypeVar, Any, NoReturn
+
+Fun = TypeVar("Fun", bound=Callable[..., Any])
+
+def const(x: int) -> int:
+    "Emulate making a constant"
+    return x
+
+def native(f: Fun) -> Fun:
+    "Emulate making a native"
+    return f
+
+def viper(f: Fun) -> NoReturn:
+    "User is attempting to use a viper code emitter"
+    raise SyntaxError("invalid micropython decorator")
+
+def asm_thumb(f: Fun) -> NoReturn:
+    "User is attempting to use an inline assembler"
+    raise SyntaxError("invalid micropython decorator")

--- a/src/micropython-stubs/micropython.pyi
+++ b/src/micropython-stubs/micropython.pyi
@@ -14,16 +14,12 @@ Fun = TypeVar("Fun", bound=Callable[..., Any])
 
 def const(x: int) -> int:
     "Emulate making a constant"
-    return x
 
 def native(f: Fun) -> Fun:
     "Emulate making a native"
-    return f
 
 def viper(f: Fun) -> NoReturn:
     "User is attempting to use a viper code emitter"
-    raise SyntaxError("invalid micropython decorator")
 
 def asm_thumb(f: Fun) -> NoReturn:
     "User is attempting to use an inline assembler"
-    raise SyntaxError("invalid micropython decorator")


### PR DESCRIPTION
This allows use of micropython.const to typecheck without making any changes to the .py files themselves. It's an alternative to #608 