### PR TITLE
Update version on release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
       working-directory: docs
       run: sphinx-build -E -W -b html . _build/html
     - name: Build Python package
-      if: contains(steps.need-pypi.outputs.pyproject-toml, 'pyproject.toml')
+      if: contains(steps.need-pypi.outputs.setup-py, 'setup.py')
       run: |
         pip install --upgrade build twine
         for file in $(find -not -path "./.*" -not -path "./docs*" \( -name "*.py" -o -name "*.toml" \) ); do

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,6 @@ jobs:
       working-directory: docs
       run: sphinx-build -E -W -b html . _build/html
     - name: Build Python package
-      if: contains(steps.need-pypi.outputs.setup-py, 'setup.py')
       run: |
         pip install --upgrade build twine
         for file in $(find -not -path "./.*" -not -path "./docs*" \( -name "*.py" -o -name "*.toml" \) ); do

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,3 +47,12 @@ jobs:
     - name: Build docs
       working-directory: docs
       run: sphinx-build -E -W -b html . _build/html
+    - name: Build Python package
+      if: contains(steps.need-pypi.outputs.pyproject-toml, 'pyproject.toml')
+      run: |
+        pip install --upgrade build twine
+        for file in $(find -not -path "./.*" -not -path "./docs*" \( -name "*.py" -o -name "*.toml" \) ); do
+            sed -i -e "s/0.0.0+auto.0/1.2.3/" $file;
+        done;
+        python -m build
+        twine check dist/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,8 +32,8 @@ jobs:
         TWINE_USERNAME: ${{ secrets.pypi_username }}
         TWINE_PASSWORD: ${{ secrets.pypi_password }}
       run: |
-        for file in $(find -not -path "./.*" -not -path "./docs*" -name "*.py"); do
-            sed -i -e "s/0.0.0-auto.0/${{github.event.release.tag_name}}/" $file;
+        for file in $(find -not -path "./.*" -not -path "./docs*" \( -name "*.py" -o -name "*.toml" \) ); do
+            sed -i -e "s/0.0.0+auto.0/${{github.event.release.tag_name}}/" $file;
         done;
-        python setup.py sdist
+        python -m build
         twine upload dist/*

--- a/src/__version__.py
+++ b/src/__version__.py
@@ -2,6 +2,5 @@
 #
 # SPDX-License-Identifier: MIT
 """Return the current version"""
-VERSION = (1, 0, 0)
 
-__version__ = ".".join(map(str, VERSION))
+__version__ = VERSION = "0.0.0+auto.0"

--- a/src/board.py
+++ b/src/board.py
@@ -11,7 +11,7 @@ See `CircuitPython:board` in CircuitPython for more details.
 """
 
 
-__version__ = "0.0.0-auto.0"
+__version__ = "0.0.0+auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_Blinka.git"
 __blinka__ = True
 


### PR DESCRIPTION
1. CI will not fix version strings before uploading to PyPI!
2. Now builds pure Python wheels as well besides uploading source distributions, which hopefully speeds up installation