### PR TITLE
Adding support for Banana PI M2 Plus

### DIFF
--- a/src/adafruit_blinka/board/bananapi/bpim2plus.py
+++ b/src/adafruit_blinka/board/bananapi/bpim2plus.py
@@ -1,0 +1,82 @@
+# SPDX-FileCopyrightText: 2021 Melissa LeBlanc-Williams for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+"""Pin definitions for the Banana Pi M2 Zero."""
+
+# The Banana Pi M2 Plus uses the AllWinner H3 SoC, but pins
+# are the same as the AllWinner H3 SoC, so we import those
+from adafruit_blinka.microcontroller.allwinner.h3 import pin
+
+PA12 = pin.PA12
+SDA = pin.PA12
+PA11 = pin.PA11
+SCL = pin.PA11
+PA6 = pin.PA6
+PWM1 = pin.PA6
+PA1 = pin.PA1
+UART2_RX = pin.PA1
+PA0 = pin.PA0
+UART2_TX = pin.PA0
+PA3 = pin.PA3
+UART2_CTS = pin.PA3
+PA10 = pin.PA10
+PA12 = pin.PA12
+SDA = pin.PA12
+PA11 = pin.PA11
+SCL = pin.PA11
+PA6 = pin.PA6
+PWM1 = pin.PA6
+PA1 = pin.PA1
+UART2_RX = pin.PA1
+PA0 = pin.PA0
+UART2_TX = pin.PA0
+PA3 = pin.PA3
+UART2_CTS = pin.PA3
+PA7 = pin.PA7
+PA8 = pin.PA8
+PA9 = pin.PA9
+PA10 = pin.PA10
+PA17 = pin.PA17
+PA18 = pin.PA18
+PA19 = pin.PA19
+PA20 = pin.PA20
+PA21 = pin.PA21
+PC0 = pin.PC0
+PC1 = pin.PC1
+PC2 = pin.PC2
+PC3 = pin.PC3
+PC4 = pin.PC4
+PC7 = pin.PC7
+
+PA13 = pin.PA13
+SPI1_CS = pin.PA13
+PA14 = pin.PA14
+SPI1_CLK = pin.PA14
+PA2 = pin.PA2
+UART2_RTS = pin.PA2
+PA18 = pin.PA18
+TWI1_SCK = pin.PA18
+
+PL2 = pin.PL2
+PL4 = pin.PL4
+
+SCLK = pin.PA14
+MOSI = pin.PA15
+MISO = pin.PA16
+
+PA13 = pin.PA13
+SPI1_CS = pin.PA13
+PA14 = pin.PA14
+SPI1_CLK = pin.PA14
+PA2 = pin.PA2
+UART2_RTS = pin.PA2
+PA18 = pin.PA18
+TWI1_SCK = pin.PA18
+PG6 = pin.PG6
+UART1_TX = pin.PG6
+PG7 = pin.PG7
+UART1_RX = pin.PG7
+
+SCLK = pin.PA14
+MOSI = pin.PA15
+MISO = pin.PA16

--- a/src/board.py
+++ b/src/board.py
@@ -130,6 +130,9 @@ elif board_id == ap_board.ORANGE_PI_4_LTS:
 elif board_id == ap_board.BANANA_PI_M2_ZERO:
     from adafruit_blinka.board.bananapi.bpim2zero import *
 
+elif board_id == ap_board.BANANA_PI_M2_PLUS:
+    from adafruit_blinka.board.bananapi.bpim2plus import *
+
 elif board_id == ap_board.BANANA_PI_M5:
     from adafruit_blinka.board.bananapi.bpim5 import *
 


### PR DESCRIPTION
This PR adds support for the Banana PI M2 Plus. Have been using and testing these changes for a few weeks with no issues so far though I arguably have not tested all of the different pin functions. Can confirm that i2c, basic gpio, and spi work.