### PR TITLE
Added missing if query for Siemens SIMATIC IOT2050 Basic Version -> updated board.py

### DIFF
--- a/src/board.py
+++ b/src/board.py
@@ -307,6 +307,9 @@ elif board_id == ap_board.LICHEE_RV:
 elif board_id == ap_board.SIEMENS_SIMATIC_IOT2050_ADV:
     from adafruit_blinka.board.siemens.siemens_iot2050 import *
 
+elif board_id == ap_board.SIEMENS_SIMATIC_IOT2050_BASIC:
+    from adafruit_blinka.board.siemens.siemens_iot2050 import *
+
 elif board_id == ap_board.AML_S905X_CC:
     from adafruit_blinka.board.librecomputer.aml_s905x_cc_v1 import *
 


### PR DESCRIPTION
The "if query" for the SIMATIC IOT2050 Basic was missing.
It could be tested now with the new version of the SIMATIC IOT2050 Basic (FS:04 12.2022)

thanks
best regards
Martin Schnur