### PR TITLE
Minimal support for generic linux pc

### DIFF
--- a/src/adafruit_blinka/board/generic_linux_pc.py
+++ b/src/adafruit_blinka/board/generic_linux_pc.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: 2021 Melissa LeBlanc-Williams for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+"""(Empty) definitions for the GENERIC_LINUX_PC."""

--- a/src/board.py
+++ b/src/board.py
@@ -11,7 +11,7 @@ See `CircuitPython:board` in CircuitPython for more details.
 """
 
 
-__version__ = "0.0.0+auto.0"
+__version__ = "8.12.0"
 __repo__ = "https://github.com/adafruit/Adafruit_Blinka.git"
 __blinka__ = True
 
@@ -309,6 +309,9 @@ elif board_id == ap_board.SIEMENS_SIMATIC_IOT2050_ADV:
 
 elif board_id == ap_board.AML_S905X_CC:
     from adafruit_blinka.board.librecomputer.aml_s905x_cc_v1 import *
+
+elif board_id == ap_board.GENERIC_LINUX_PC:
+    from adafruit_blinka.board.generic_linux_pc import *
 
 elif "sphinx" in sys.modules:
     pass

--- a/src/board.py
+++ b/src/board.py
@@ -11,7 +11,7 @@ See `CircuitPython:board` in CircuitPython for more details.
 """
 
 
-__version__ = "8.12.0"
+__version__ = "0.0.0+auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_Blinka.git"
 __blinka__ = True
 


### PR DESCRIPTION
This pull requests adds minimal support for boards with id 'GENERIC_LINUX_PC'. With this patch, an `import board` no longer fails and `board.board_id` is something to work with.

I am using this together with @FoamyGuy s <https://github.com/FoamyGuy/Blinka_Displayio_PyGameDisplay> package to run CircuitPython-code on a normal linux-box (mainly to create screenshots). With this patch, `import board` does not fail anymore.