### PR TITLE
Added minimal beaglebone blue support

### DIFF
--- a/src/adafruit_blinka/board/beagleboard/beaglebone_blue.py
+++ b/src/adafruit_blinka/board/beagleboard/beaglebone_blue.py
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: 2021 Melissa LeBlanc-Williams for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+"""Pin definitions for the Beaglebone Blue."""
+from adafruit_blinka.microcontroller.am335x import pin
+
+# common to all beagles
+LED_USR0 = pin.USR0
+LED_USR1 = pin.USR1
+LED_USR2 = pin.USR2
+LED_USR3 = pin.USR3
+
+SDA = pin.I2C1_SDA
+SCL = pin.I2C1_SCL
+

--- a/src/adafruit_blinka/board/beagleboard/beaglebone_blue.py
+++ b/src/adafruit_blinka/board/beagleboard/beaglebone_blue.py
@@ -12,4 +12,3 @@ LED_USR3 = pin.USR3
 
 SDA = pin.I2C1_SDA
 SCL = pin.I2C1_SCL
-

--- a/src/board.py
+++ b/src/board.py
@@ -61,6 +61,9 @@ elif board_id == ap_board.BEAGLEBONE:
 elif board_id == ap_board.BEAGLEBONE_BLACK:
     from adafruit_blinka.board.beagleboard.beaglebone_black import *
 
+elif board_id == ap_board.BEAGLEBONE_BLUE:
+    from adafruit_blinka.board.beagleboard.beaglebone_blue import *
+
 elif board_id == ap_board.BEAGLEBONE_GREEN:
     from adafruit_blinka.board.beagleboard.beaglebone_black import *
 


### PR DESCRIPTION
Hi, I needed to use I2C on the BeagleBone Blue, so I added support for that in the library.  This pr only includes pins that I have tested personally, but someone with more knowledge about the blue might be able to fill in the blanks.  According to [this](https://github.com/adafruit/adafruit-beaglebone-io-python/issues/313#issuecomment-513904700), it might be pretty similar to the black, but I don't know anything for sure.  Would the maintainers want a partially supported board like this included in the official library or kept as a fork?  