### PR TITLE
Add second I2C to coral_dev_board.py

### DIFF
--- a/src/adafruit_blinka/board/coral_dev_board.py
+++ b/src/adafruit_blinka/board/coral_dev_board.py
@@ -8,6 +8,9 @@ from adafruit_blinka.microcontroller.nxp_imx8m import pin
 # Board name = RPI name [= alias] = pin name
 I2C2_SDA = D2 = SDA = pin.I2C2_SDA
 I2C2_SCL = D3 = SCL = pin.I2C2_SCL
+I2C3_SDA = SDA3 = pin.I2C3_SDA
+I2C3_SCL = SCL3 = pin.I2C3_SCL
+
 
 PWM1 = D12 = pin.PWM1
 PWM2 = D13 = pin.PWM2


### PR DESCRIPTION
I needed to use the second I2C port (I2C3) and so I added this locally, and it works.