### PR TITLE
Add Release Drafter to make releases easier

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 Melissa LeBlanc-Williams, written for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+
 categories:
   - title: "New Boards"
     collapse-after: 1

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,17 @@
+categories:
+  - title: "Breaking Changes"
+    labels:
+      - "breaking change"
+  - title: "New Boards"
+    collapse-after: 1
+    labels:
+      - "New Board"
+change-template: "- $TITLE #$NUMBER by @$AUTHOR"
+template: |
+  ## What's Changed
+
+  $CHANGES
+
+  To use in CPython, `pip3 install adafruit-blinka`.
+
+  Read the [docs](https://circuitpython.readthedocs.io/projects/blinka/en/latest/) for info on how to use it.

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,11 +1,8 @@
 categories:
-  - title: "Breaking Changes"
-    labels:
-      - "breaking change"
   - title: "New Boards"
     collapse-after: 1
     labels:
-      - "New Board"
+      - "New Board Request"
 change-template: "- $TITLE #$NUMBER by @$AUTHOR"
 template: |
   ## What's Changed

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,21 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  update_release_draft:
+    permissions:
+        # write permission is required to create a github release
+        contents: write
+        pull-requests: read
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 Melissa LeBlanc-Williams, written for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+
 name: Release Drafter
 
 on:


### PR DESCRIPTION
Similar to https://github.com/adafruit/Adafruit_Python_PlatformDetect/pull/311. Release Drafter is a GitHub Actions library that allows automatic generation of releases so that it is much easier to create informative release info.