### PR TITLE
Separate SPDX to separate files for issue markdown

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,7 +1,10 @@
+<<<<<<< Updated upstream
 <!--
 SPDX-FileCopyrightText: 2023 Melissa LeBlanc-Williams for Adafruit Industries
 SPDX-License-Identifier: MIT
 -->
+=======
+>>>>>>> Stashed changes
 ---
 name: 🚀 Feature Request
 about: Suggest an idea for this project

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,10 +1,3 @@
-<<<<<<< Updated upstream
-<!--
-SPDX-FileCopyrightText: 2023 Melissa LeBlanc-Williams for Adafruit Industries
-SPDX-License-Identifier: MIT
--->
-=======
->>>>>>> Stashed changes
 ---
 name: 🚀 Feature Request
 about: Suggest an idea for this project

--- a/.github/ISSUE_TEMPLATE/feature_request.md.license
+++ b/.github/ISSUE_TEMPLATE/feature_request.md.license
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2023 Melissa LeBlanc-Williams for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT

--- a/.github/ISSUE_TEMPLATE/new_board_request.md
+++ b/.github/ISSUE_TEMPLATE/new_board_request.md
@@ -1,7 +1,3 @@
-<!--
-SPDX-FileCopyrightText: 2023 Melissa LeBlanc-Williams for Adafruit Industries
-SPDX-License-Identifier: MIT
--->
 ---
 name: 🚀 New Board Request
 about: Request Support for a New Board

--- a/.github/ISSUE_TEMPLATE/new_board_request.md.license
+++ b/.github/ISSUE_TEMPLATE/new_board_request.md.license
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2023 Melissa LeBlanc-Williams for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT


### PR DESCRIPTION
Apparently adding inline SPDX headers breaks the files