### PR TITLE
Update busio to avoid always triggering frequency warning

### DIFF
--- a/src/busio.py
+++ b/src/busio.py
@@ -138,6 +138,8 @@ class I2C(Lockable):
 
         if detector.board.any_embedded_linux:
             from adafruit_blinka.microcontroller.generic_linux.i2c import I2C as _I2C
+            if frequency == 100000:
+                frequency = None    # Set to None if default to avoid triggering warning
         elif detector.board.ftdi_ft2232h:
             from adafruit_blinka.microcontroller.ftdi_mpsse.mpsse.i2c import I2C as _I2C
         else:

--- a/src/busio.py
+++ b/src/busio.py
@@ -138,8 +138,9 @@ class I2C(Lockable):
 
         if detector.board.any_embedded_linux:
             from adafruit_blinka.microcontroller.generic_linux.i2c import I2C as _I2C
+
             if frequency == 100000:
-                frequency = None    # Set to None if default to avoid triggering warning
+                frequency = None  # Set to None if default to avoid triggering warning
         elif detector.board.ftdi_ft2232h:
             from adafruit_blinka.microcontroller.ftdi_mpsse.mpsse.i2c import I2C as _I2C
         else:


### PR DESCRIPTION
I realized the reason the warning was commented out before #708 is because busio uses a default frequency value of 100000 which will always trigger the warning. This will fix it so if the user isn't trying to set the frequency to something besides the default, it won't trigger the warning.