### PR TITLE
Added Pi 5 Support + Fixed libgpiod pulls

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-Adafruit-PlatformDetect>=3.52.0
+Adafruit-PlatformDetect>=3.53.0
 Adafruit-PureIO>=1.1.7
 Jetson.GPIO; platform_machine=='aarch64'
-RPi.GPIO; platform_machine=='armv7l' or platform_machine=='armv6l'
-rpi_ws281x>=4.0.0; platform_machine=='armv7l' or platform_machine=='armv6l'
+RPi.GPIO; platform_machine=='armv7l' or platform_machine=='armv6l' or platform_machine=='aarch64'
+rpi_ws281x>=4.0.0; platform_machine=='armv7l' or platform_machine=='armv6l' or platform_machine=='aarch64'
 sysv_ipc>=1.1.0; sys_platform == 'linux' and platform_machine!='mips'
 pyftdi>=0.40.0
 binho-host-adapter>=0.1.6

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ if os.path.exists("/proc/device-tree/compatible"):
         or b"brcm,bcm2837" in compat
         or b"brcm,bcm2838" in compat
         or b"brcm,bcm2711" in compat
+        or b"brcm,bcm2712" in compat
     ):
         board_reqs = ["RPi.GPIO", "rpi_ws281x>=4.0.0", "sysv_ipc>=1.1.0"]
     if (
@@ -86,7 +87,7 @@ setup(
     },
     include_package_data=True,
     install_requires=[
-        "Adafruit-PlatformDetect>=3.52.0",
+        "Adafruit-PlatformDetect>=3.53.0",
         "Adafruit-PureIO>=1.1.7",
         "pyftdi>=0.40.0",
         "adafruit-circuitpython-typing",

--- a/src/adafruit_blinka/board/raspberrypi/raspi_5b.py
+++ b/src/adafruit_blinka/board/raspberrypi/raspi_5b.py
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: 2023 Melissa LeBlanc-Williams for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+"""Pin definitions for Raspberry Pi 5 models using the BCM2712."""
+
+from adafruit_blinka.microcontroller.bcm2712 import pin
+
+D0 = pin.D0
+D1 = pin.D1
+
+D2 = pin.D2
+SDA = pin.SDA
+D3 = pin.D3
+SCL = pin.SCL
+
+D4 = pin.D4
+D5 = pin.D5
+D6 = pin.D6
+
+D7 = pin.D7
+CE1 = pin.D7
+D8 = pin.D8
+CE0 = pin.D8
+D9 = pin.D9
+MISO = pin.D9
+D10 = pin.D10
+MOSI = pin.D10
+D11 = pin.D11
+SCLK = pin.D11
+SCK = pin.D11
+
+D12 = pin.D12
+D13 = pin.D13
+
+D14 = pin.D14
+TXD = pin.D14
+D15 = pin.D15
+RXD = pin.D15
+# create alias for most of the examples
+TX = pin.D14
+RX = pin.D15
+
+D16 = pin.D16
+D17 = pin.D17
+D18 = pin.D18
+D19 = pin.D19
+MISO_1 = pin.D19
+D20 = pin.D20
+MOSI_1 = pin.D20
+D21 = pin.D21
+SCLK_1 = pin.D21
+SCK_1 = pin.D21
+D22 = pin.D22
+D23 = pin.D23
+D24 = pin.D24
+D25 = pin.D25
+D26 = pin.D26
+D27 = pin.D27

--- a/src/adafruit_blinka/microcontroller/bcm2712/pin.py
+++ b/src/adafruit_blinka/microcontroller/bcm2712/pin.py
@@ -1,0 +1,95 @@
+# SPDX-FileCopyrightText: 2023 Melissa LeBlanc-Williams for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+"""Broadcom BCM2712 pin names"""
+from adafruit_blinka.microcontroller.generic_linux.libgpiod_pin import Pin
+
+# Pi 1B rev1 only?
+D0 = Pin((4, 0))
+D1 = Pin((4, 1))
+
+D2 = Pin((4, 2))
+SDA = Pin((4, 2))
+D3 = Pin((4, 3))
+SCL = Pin((4, 3))
+
+D4 = Pin((4, 4))
+D5 = Pin((4, 5))
+D6 = Pin((4, 6))
+
+D7 = Pin((4, 7))
+CE1 = Pin((4, 7))
+D8 = Pin((4, 8))
+CE0 = Pin((4, 8))
+D9 = Pin((4, 9))
+MISO = Pin((4, 9))
+D10 = Pin((4, 10))
+MOSI = Pin((4, 10))
+D11 = Pin((4, 11))
+SCLK = Pin((4, 11))  # Raspberry Pi naming
+SCK = Pin((4, 11))  # CircuitPython naming
+
+D12 = Pin((4, 12))
+D13 = Pin((4, 13))
+
+D14 = Pin((4, 14))
+TXD = Pin((4, 14))
+D15 = Pin((4, 15))
+RXD = Pin((4, 15))
+
+D16 = Pin((4, 16))
+D17 = Pin((4, 17))
+D18 = Pin((4, 18))
+D19 = Pin((4, 19))
+MISO_1 = Pin((4, 19))
+D20 = Pin((4, 20))
+MOSI_1 = Pin((4, 20))
+D21 = Pin((4, 21))
+SCLK_1 = Pin((4, 21))
+SCK_1 = Pin((4, 21))
+D22 = Pin((4, 22))
+D23 = Pin((4, 23))
+D24 = Pin((4, 24))
+D25 = Pin((4, 25))
+D26 = Pin((4, 26))
+D27 = Pin((4, 27))
+D28 = Pin((4, 28))
+D29 = Pin((4, 29))
+D30 = Pin((4, 30))
+D31 = Pin((4, 31))
+D32 = Pin((4, 32))
+D33 = Pin((4, 33))
+D34 = Pin((4, 34))
+D35 = Pin((4, 35))
+D36 = Pin((4, 36))
+D37 = Pin((4, 37))
+D38 = Pin((4, 38))
+D39 = Pin((4, 39))
+D40 = Pin((4, 40))
+MISO_2 = Pin((4, 40))
+D41 = Pin((4, 41))
+MOSI_2 = Pin((4, 41))
+D42 = Pin((4, 42))
+SCLK_2 = Pin((4, 42))
+SCK_2 = Pin((4, 43))
+D43 = Pin((4, 43))
+D44 = Pin((4, 44))
+D45 = Pin((4, 45))
+
+# ordered as spiId, sckId, mosiId, misoId
+spiPorts = (
+    (0, SCLK, MOSI, MISO),
+    (1, SCLK_1, MOSI_1, MISO_1),
+    (2, SCLK_2, MOSI_2, MISO_2),
+)
+
+# ordered as uartId, txId, rxId
+uartPorts = ((1, TXD, RXD),)
+
+# These are the known hardware I2C ports / pins.
+# For software I2C ports created with the i2c-gpio overlay, see:
+#     https://github.com/adafruit/Adafruit_Python_Extended_Bus
+i2cPorts = (
+    (1, SCL, SDA),
+    (0, D1, D0),  # both pi 1 and pi 2 i2c ports!
+)

--- a/src/adafruit_blinka/microcontroller/generic_linux/libgpiod_pin.py
+++ b/src/adafruit_blinka/microcontroller/generic_linux/libgpiod_pin.py
@@ -62,31 +62,18 @@ class Pin:
                 self._line.release()
                 if pull is not None:
                     if pull == self.PULL_UP:
-                        if hasattr(gpiod, "line") and hasattr(
-                            gpiod.line, "BIAS_PULL_UP"
-                        ):
-                            config = gpiod.line_request()
-                            config.consumer = self._CONSUMER
-                            config.request_type = gpiod.line.BIAS_PULL_UP
-                            self._line.request(config)
+                        if hasattr(gpiod, "LINE_REQ_FLAG_BIAS_PULL_UP"):
+                            flags |= gpiod.LINE_REQ_FLAG_BIAS_PULL_UP
                         else:
-                            self._line.request(
-                                consumer=self._CONSUMER,
-                                type=gpiod.LINE_REQ_DIR_IN,
-                                flags=flags,
-                            )
                             raise NotImplementedError(
                                 "Internal pullups not supported in this version of libgpiod, "
                                 "use physical resistor instead!"
                             )
                     elif pull == self.PULL_DOWN:
                         if hasattr(gpiod, "line") and hasattr(
-                            gpiod.line, "BIAS_PULL_DOWN"
+                            gpiod, "LINE_REQ_FLAG_BIAS_PULL_DOWN"
                         ):
-                            config = gpiod.line_request()
-                            config.consumer = self._CONSUMER
-                            config.request_type = gpiod.line.BIAS_PULL_DOWN
-                            self._line.request(config)
+                            flags |= gpiod.LINE_REQ_FLAG_BIAS_PULL_DOWN
                         else:
                             raise NotImplementedError(
                                 "Internal pulldowns not supported in this version of libgpiod, "
@@ -94,12 +81,14 @@ class Pin:
                             )
                     elif pull == self.PULL_NONE:
                         if hasattr(gpiod, "line") and hasattr(
-                            gpiod.line, "BIAS_DISABLE"
+                            gpiod, "LINE_REQ_FLAG_BIAS_DISABLE"
                         ):
-                            config = gpiod.line_request()
-                            config.consumer = self._CONSUMER
-                            config.request_type = gpiod.line.BIAS_DISABLE
-                            self._line.request(config)
+                            flags |= gpiod.LINE_REQ_FLAG_BIAS_DISABLE
+                        else:
+                            raise NotImplementedError(
+                                "Internal pulldowns not supported in this version of libgpiod, "
+                                "use physical resistor instead!"
+                            )
                     else:
                         raise RuntimeError(f"Invalid pull for pin: {self.id}")
 

--- a/src/board.py
+++ b/src/board.py
@@ -39,9 +39,12 @@ elif board_id == ap_board.RASPBERRY_PI_PICO:
 elif (
     detector.board.RASPBERRY_PI_4B
     or detector.board.RASPBERRY_PI_CM4
+    or detector.board.RASPBERRY_PI_CM4S
     or detector.board.RASPBERRY_PI_400
 ):
     from adafruit_blinka.board.raspberrypi.raspi_4b import *
+elif detector.board.RASPBERRY_PI_5:
+    from adafruit_blinka.board.raspberrypi.raspi_5b import *
 
 elif detector.board.any_raspberry_pi_40_pin:
     from adafruit_blinka.board.raspberrypi.raspi_40pin import *

--- a/src/busio.py
+++ b/src/busio.py
@@ -194,18 +194,17 @@ class I2C(Lockable):
             if end is None:
                 end = len(buffer)
             buffer = memoryview(buffer)[start:end]
-        stop = True  # remove for efficiency later
-        return self._i2c.readfrom_into(address, buffer, stop=stop)
+        return self._i2c.readfrom_into(address, buffer, stop=True)
 
-    def writeto(self, address, buffer, *, start=0, end=None, stop=True):
+    def writeto(self, address, buffer, *, start=0, end=None):
         """Write to a device at specified address from a buffer"""
         if isinstance(buffer, str):
             buffer = bytes([ord(x) for x in buffer])
         if start != 0 or end is not None:
             if end is None:
-                return self._i2c.writeto(address, memoryview(buffer)[start:], stop=stop)
-            return self._i2c.writeto(address, memoryview(buffer)[start:end], stop=stop)
-        return self._i2c.writeto(address, buffer, stop=stop)
+                return self._i2c.writeto(address, memoryview(buffer)[start:], stop=True)
+            return self._i2c.writeto(address, memoryview(buffer)[start:end], stop=True)
+        return self._i2c.writeto(address, buffer, stop=True)
 
     def writeto_then_readfrom(
         self,

--- a/src/digitalio.py
+++ b/src/digitalio.py
@@ -12,11 +12,21 @@ See `CircuitPython:digitalio` in CircuitPython for more details.
 
 from adafruit_blinka.agnostic import board_id, detector
 
-# pylint: disable=ungrouped-imports,wrong-import-position
+# pylint: disable=ungrouped-imports,wrong-import-position,unused-wildcard-import,wildcard-import
 
 # By Chip Class
 if detector.chip.BCM2XXX:
-    from adafruit_blinka.microcontroller.bcm283x.pin import Pin
+    if board_id in (
+        "RASPBERRY_PI_4B",
+        "RASPBERRY_PI_400",
+        "RASPBERRY_PI_CM4",
+        "RASPBERRY_PI_CM4S",
+    ):
+        from adafruit_blinka.microcontroller.bcm2711.pin import *
+    elif board_id in ("RASPBERRY_PI_5",):
+        from adafruit_blinka.microcontroller.bcm2712.pin import *
+    else:
+        from adafruit_blinka.microcontroller.bcm283x.pin import Pin
 elif detector.chip.AM33XX:
     from adafruit_blinka.microcontroller.am335x.pin import Pin
 elif detector.chip.AM65XX:

--- a/src/microcontroller/pin.py
+++ b/src/microcontroller/pin.py
@@ -17,14 +17,19 @@ elif chip_id == ap_chip.STM32F405:
 elif chip_id == ap_chip.RP2040:
     from adafruit_blinka.microcontroller.rp2040.pin import *
 elif chip_id == ap_chip.BCM2XXX:
-    if board_id in [
+    if board_id in (
         "RASPBERRY_PI_4B",
         "RASPBERRY_PI_400",
         "RASPBERRY_PI_CM4",
-    ]:
+        "RASPBERRY_PI_CM4S",
+    ):
         from adafruit_blinka.microcontroller.bcm2711.pin import *
+    elif board_id in ("RASPBERRY_PI_5",):
+        from adafruit_blinka.microcontroller.bcm2712.pin import *
     else:
         from adafruit_blinka.microcontroller.bcm283x.pin import *
+elif chip_id == ap_chip.BCM2712:
+    from adafruit_blinka.microcontroller.bcm2712.pin import *
 elif chip_id == ap_chip.DRA74X:
     from adafruit_blinka.microcontroller.dra74x.pin import *
 elif chip_id == ap_chip.AM33XX:

--- a/src/microcontroller/pin.py
+++ b/src/microcontroller/pin.py
@@ -28,8 +28,6 @@ elif chip_id == ap_chip.BCM2XXX:
         from adafruit_blinka.microcontroller.bcm2712.pin import *
     else:
         from adafruit_blinka.microcontroller.bcm283x.pin import *
-elif chip_id == ap_chip.BCM2712:
-    from adafruit_blinka.microcontroller.bcm2712.pin import *
 elif chip_id == ap_chip.DRA74X:
     from adafruit_blinka.microcontroller.dra74x.pin import *
 elif chip_id == ap_chip.AM33XX:


### PR DESCRIPTION
This adds support for the Raspberry Pi 5 as well as the Compute Module 4S (untested). RPi.GPIO is not currently working on the Pi 5 and since we already had a pin for libgpiod, I went with that. In order to maintain compatibility, I updated the code to fix the pullups and pulldowns, which should be helpful for other boards that use libgpiod.