### PR TITLE
ODROIDs: Support aliased alt functions

### DIFF
--- a/src/adafruit_blinka/microcontroller/alias.py
+++ b/src/adafruit_blinka/microcontroller/alias.py
@@ -2,9 +2,14 @@
 #
 # SPDX-License-Identifier: MIT
 
+"""
+Device Tree Alias Functions
+"""
+
 from typing import Optional
 import os
 import re
+
 
 def get_dts_alias(device: str) -> Optional[str]:
     """Get the Device Tree Alias"""

--- a/src/adafruit_blinka/microcontroller/alias.py
+++ b/src/adafruit_blinka/microcontroller/alias.py
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: 2023 Steve Jeong for Hardkernel
+#
+# SPDX-License-Identifier: MIT
+
+from typing import Optional
+import os
+import re
+
+def get_dts_alias(device: str) -> Optional[str]:
+    """Get the Device Tree Alias"""
+    uevent_path = "/sys/bus/platform/devices/" + device + "/uevent"
+    if os.path.exists(uevent_path):
+        with open(uevent_path, "r", encoding="utf-8") as fd:
+            pattern = r"^OF_ALIAS_0=(.*)$"
+            uevent = fd.read().split("\n")
+            for line in uevent:
+                match = re.search(pattern, line)
+                if match:
+                    return match.group(1).upper()
+    return None

--- a/src/adafruit_blinka/microcontroller/amlogic/meson_g12_common/pin.py
+++ b/src/adafruit_blinka/microcontroller/amlogic/meson_g12_common/pin.py
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2021 Melissa LeBlanc-Williams for Adafruit Industries
+# SPDX-FileCopyrightText: 2023 Steve Jeong for Hardkernel
 #
 # SPDX-License-Identifier: MIT
 """
@@ -11,9 +12,9 @@ Linux kernel 5.4.y (mainline)
     linux/arch/arm64/boot/dts/amlogic/meson-g12-common.dtsi
 """
 
-from typing import Optional
-import os
-import re
+from adafruit_blinka.agnostic import detector
+from adafruit_blinka.microcontroller.alias import get_dts_alias
+from adafruit_blinka.microcontroller.generic_linux.libgpiod_pin import Pin
 
 try:
     import gpiod
@@ -21,7 +22,6 @@ except ImportError:
     raise ImportError(
         "libgpiod Python bindings not found, please install and try again!"
     ) from ImportError
-from adafruit_blinka.microcontroller.generic_linux.libgpiod_pin import Pin
 
 if hasattr(gpiod, "Chip"):
     chip0 = gpiod.Chip("0")
@@ -122,43 +122,40 @@ SPI0_MISO = GPIOX_9
 SPI0_MOSI = GPIOX_8
 SPI0_CS0 = GPIOX_10
 
-# ordered as spiId, sckId, mosiId, misoId
-spiPorts = ((0, SPI0_SCLK, SPI0_MOSI, SPI0_MISO),)
-
 UART1_TX = GPIOX_12
 UART1_RX = GPIOX_13
-
-# ordered as uartId, txId, rxId
-uartPorts = ((1, UART1_TX, UART1_RX),)
-
-
-def get_dts_alias(device: str) -> Optional[str]:
-    """Get the Device Tree Alias"""
-    uevent_path = "/sys/bus/platform/devices/" + device + "/uevent"
-    if os.path.exists(uevent_path):
-        with open(uevent_path, "r", encoding="utf-8") as fd:
-            pattern = r"^OF_ALIAS_0=(.*)$"
-            uevent = fd.read().split("\n")
-            for line in uevent:
-                match = re.search(pattern, line)
-                if match:
-                    return match.group(1).upper()
-    return None
-
 
 # ordered as i2cId, sclId, sdaId
 i2cPorts = []
 
-alias = get_dts_alias("ffd1d000.i2c")
-if alias is not None:
-    globals()[alias + "_SCL"] = GPIOX_18
-    globals()[alias + "_SDA"] = GPIOX_17
-    i2cPorts.append((int(alias[3]), GPIOX_18, GPIOX_17))
+# ordered as spiId, sckId, mosiId, misoId
+spiPorts = ((0, SPI0_SCLK, SPI0_MOSI, SPI0_MISO),)
 
-alias = get_dts_alias("ffd1c000.i2c")
-if alias is not None:
-    globals()[alias + "_SCL"] = GPIOA_15
-    globals()[alias + "_SDA"] = GPIOA_14
-    i2cPorts.append((int(alias[3]), GPIOA_15, GPIOA_14))
+# ordered as uartId, txId, rxId
+uartPorts = [(1, UART1_TX, UART1_RX),]
+
+board = detector.board.id
+if board in ("ODROID_C4", "ODROID_N2"):
+    alias = get_dts_alias("ffd1d000.i2c")
+    if alias is not None:
+        globals()[alias + "_SCL"] = GPIOX_18
+        globals()[alias + "_SDA"] = GPIOX_17
+        i2cPorts.append((int(alias[3]), GPIOX_18, GPIOX_17))
+    alias = get_dts_alias("ffd1c000.i2c")
+    if alias is not None:
+        globals()[alias + "_SCL"] = GPIOA_15
+        globals()[alias + "_SDA"] = GPIOA_14
+        i2cPorts.append((int(alias[3]), GPIOA_15, GPIOA_14))
+    alias = get_dts_alias("fdd24000.serial")
+    if alias is not None:
+        globals()[alias + "_TX"] = GPIOX_12
+        globals()[alias + "_RX"] = GPIOX_13
+        uartPorts.append((int(alias[3]), GPIOX_12, GPIOX_13))
+    alias = get_dts_alias("fdd23000.serial")
+    if alias is not None:
+        globals()[alias + "_TX"] = GPIOX_6
+        globals()[alias + "_RX"] = GPIOX_7
+        uartPorts.append((int(alias[3]), GPIOX_6, GPIOX_7))
 
 i2cPorts = tuple(i2cPorts)
+uartPorts = tuple(uartPorts)

--- a/src/adafruit_blinka/microcontroller/amlogic/meson_g12_common/pin.py
+++ b/src/adafruit_blinka/microcontroller/amlogic/meson_g12_common/pin.py
@@ -132,7 +132,9 @@ i2cPorts = []
 spiPorts = ((0, SPI0_SCLK, SPI0_MOSI, SPI0_MISO),)
 
 # ordered as uartId, txId, rxId
-uartPorts = [(1, UART1_TX, UART1_RX),]
+uartPorts = [
+    (1, UART1_TX, UART1_RX),
+]
 
 board = detector.board.id
 if board in ("ODROID_C4", "ODROID_N2"):

--- a/src/adafruit_blinka/microcontroller/rockchip/rk3566/pin.py
+++ b/src/adafruit_blinka/microcontroller/rockchip/rk3566/pin.py
@@ -5,6 +5,8 @@
 
 """A Pin class for use with Rockchip RK3566."""
 
+from adafruit_blinka.agnostic import detector
+from adafruit_blinka.microcontroller.alias import get_dts_alias
 from adafruit_blinka.microcontroller.generic_linux.libgpiod_pin import Pin
 
 GPIO0_A2 = Pin((0, 2))
@@ -151,18 +153,18 @@ PWM0 = GPIO0_B7
 PWM1 = GPIO0_C7
 
 # ordered as i2cId, SCL, SDA
-i2cPorts = (
+i2cPorts = [
     (1, I2C1_SCL, I2C1_SDA),
     (2, I2C2_SCL_M0, I2C2_SDA_M0),
     (3, I2C3_SCL_M0, I2C3_SDA_M0),
     (5, I2C5_SCL_M0, I2C5_SDA_M0),
-)
+]
 
 # ordered as spiId, sckId, mosiId, misoId
-spiPorts = (
+spiPorts = [
     (3, SPI3_CLK_M0, SPI3_MOSI_M0, SPI3_MISO_M0),
     (3, SPI3_CLK_M1, SPI3_MOSI_M1, SPI3_MISO_M1),
-)
+]
 
 # SysFS pwm outputs, pwm channel and pin in first tuple
 pwmOuts = (
@@ -170,5 +172,35 @@ pwmOuts = (
     ((0, 0), PWM1),
 )
 
+uartPorts = []
+
 # SysFS analog inputs, Ordered as analog analogInId, device, and channel
 analogIns = ((ADC_AIN3, 0, 3),)
+
+board = detector.board.id
+if board in ("ODROID_M1S"):
+    alias = get_dts_alias("fe5c0000.i2c")
+    if alias is not None:
+        globals()[alias + "_SCL"] = GPIO3_B5
+        globals()[alias + "_SDA"] = GPIO3_B6
+        i2cPorts.append((int(alias[3]), GPIO3_B5, GPIO3_B6))
+    alias = get_dts_alias("fe620000.spi")
+    if alias is not None:
+        globals()[alias + "_CLK"] = GPIO3_C3
+        globals()[alias + "_MOSI"] = GPIO3_C1
+        globals()[alias + "_MISO"] = GPIO3_C2
+        spiPorts.append((int(alias[3]), GPIO3_C3, GPIO3_C1, GPIO3_C2))
+    alias = get_dts_alias("fdd50000.serial")
+    if alias is not None:
+        globals()[alias + "_TX"] = GPIO0_C1
+        globals()[alias + "_RX"] = GPIO0_C0
+        uartPorts.append((int(alias[3]), GPIO0_C1, GPIO0_C0))
+    alias = get_dts_alias("fe6a0000.serial")
+    if alias is not None:
+        globals()[alias + "_TX"] = GPIO2_A4
+        globals()[alias + "_RX"] = GPIO2_A3
+        uartPorts.append((int(alias[3]), GPIO2_A4, GPIO2_A3))
+
+i2cPorts = tuple(i2cPorts)
+spiPorts = tuple(spiPorts)
+uartPorts = tuple(uartPorts)

--- a/src/adafruit_blinka/microcontroller/rockchip/rk3568b2/pin.py
+++ b/src/adafruit_blinka/microcontroller/rockchip/rk3568b2/pin.py
@@ -1,9 +1,12 @@
 # SPDX-FileCopyrightText: 2022 MrPanc0 for Adafruit Industries
+# SPDX-FileCopyrightText: 2023 Steve Jeong for Hardkernel
 #
 # SPDX-License-Identifier: MIT
 
 """A Pin class for use with Rockchip RK3568B2."""
 
+from adafruit_blinka.agnostic import detector
+from adafruit_blinka.microcontroller.alias import get_dts_alias
 from adafruit_blinka.microcontroller.generic_linux.libgpiod_pin import Pin
 
 GPIO3C_6 = Pin((3, 22))
@@ -35,17 +38,14 @@ ADC_AIN0 = 37
 ADC_AIN1 = 40
 
 # I2C
-I2C0_SCL = GPIO3B_5
-I2C0_SDA = GPIO3B_6
 I2C1_SCL = GPIO0B_3
 I2C1_SDA = GPIO0B_4
 
 # SPI
-SPI0_CS = GPIO2D_2
-SPI0_SCLK = GPIO2D_3
-SPI0_MISO = GPIO2D_0
-SPI0_MOSI = GPIO2D_1
-
+SPI0_CS_M1 = GPIO2D_2
+SPI0_SCLK_M1 = GPIO2D_3
+SPI0_MISO_M1 = GPIO2D_0
+SPI0_MOSI_M1 = GPIO2D_1
 
 # UART
 UART0_TX = GPIO0C_1
@@ -58,13 +58,9 @@ UART1_RX = GPIO3D_7
 # PWM1 = GPIO4_C6
 
 # ordered as i2cId, SCL, SDA
-i2cPorts = (
-    (0, I2C0_SCL, I2C0_SDA),
+i2cPorts = [
     (1, I2C1_SCL, I2C1_SDA),
-)
-
-# ordered as spiId, sckId, mosiId, misoId
-spiPorts = ((1, SPI0_SCLK, SPI0_MOSI, SPI0_MISO),)
+]
 
 # SysFS pwm outputs, pwm channel and pin in first tuple
 # pwmOuts = (
@@ -72,8 +68,36 @@ spiPorts = ((1, SPI0_SCLK, SPI0_MOSI, SPI0_MISO),)
 #   ((1, 0), PWM1),
 # )
 
+# ordered as spiId, sckId, mosiId, misoId
+spiPorts = ((0, SPI0_SCLK_M1, SPI0_MOSI_M1, SPI0_MISO_M1),)
+
+# ordered as uartId, txId, rxId
+uartPorts = []
+
 # SysFS analog inputs, Ordered as analog analogInId, device, and channel
 analogIns = (
     (ADC_AIN0, 0, 0),
     (ADC_AIN1, 0, 0),
 )
+
+board = detector.board.id
+if board in ("ODROID_M1"):
+    alias = get_dts_alias("fe5c0000.i2c")
+    if alias is not None:
+        globals()[alias + "_SCL"] = GPIO3B_5
+        globals()[alias + "_SDA"] = GPIO3B_6
+        i2cPorts.append((int(alias[3]), GPIO3B_5, GPIO3B_6))
+    alias = get_dts_alias("fdd50000.serial")
+    if alias is not None:
+        globals()[alias + "_TX"] = GPIO0C_1
+        globals()[alias + "_RX"] = GPIO0C_0
+        uartPorts.append((int(alias[3]), GPIO0C_1, GPIO0C_0))
+    alias = get_dts_alias("fe650000.serial")
+    if alias is not None:
+        globals()[alias + "_TX"] = GPIO3D_6
+        globals()[alias + "_RX"] = GPIO3D_7
+        uartPorts.append((int(alias[3]), GPIO3D_6, GPIO3D_7))
+
+
+i2cPorts = tuple(i2cPorts)
+uartPorts = tuple(uartPorts)

--- a/src/microcontroller/pin.py
+++ b/src/microcontroller/pin.py
@@ -113,9 +113,10 @@ elif chip_id == ap_chip.RK3328:
 elif chip_id == ap_chip.RK3566:
     from adafruit_blinka.microcontroller.rockchip.rk3566.pin import *
 elif chip_id == ap_chip.RK3568:
-    from adafruit_blinka.microcontroller.rockchip.rk3568.pin import *
-elif chip_id == ap_chip.RK3568B2:
-    from adafruit_blinka.microcontroller.rockchip.rk3568b2.pin import *
+    if board_id in ("ODROID_M1"):
+        from adafruit_blinka.microcontroller.rockchip.rk3568b2.pin import *
+    else:
+        from adafruit_blinka.microcontroller.rockchip.rk3568.pin import *
 elif chip_id == ap_chip.MIPS24KC:
     from adafruit_blinka.microcontroller.atheros.ar9331.pin import *
 elif chip_id == ap_chip.MIPS24KEC:


### PR DESCRIPTION
Use rk3568 instead of rk3568b2:

- https://github.com/adafruit/Adafruit_Python_PlatformDetect/pull/331