### PR TITLE
generic_linux: pwmout: Remove duty-cycle reset in deinit flow

### DIFF
--- a/src/adafruit_blinka/microcontroller/generic_linux/sysfs_pwmout.py
+++ b/src/adafruit_blinka/microcontroller/generic_linux/sysfs_pwmout.py
@@ -158,7 +158,6 @@ class PWMOut:
     def deinit(self):
         """Deinit the sysfs PWM."""
         if self._channel is not None:
-            self.duty_cycle = 0
             try:
                 channel_path = os.path.join(
                     self._sysfs_path, self._channel_path.format(self._channel)


### PR DESCRIPTION
The 'deinit' function is called each time a property value is read and written.
However, the duty cycle continues to reset, so the sysfs PWM does not work properly.