### PR TITLE
ODROID-COMMON: Fix error of importing board

### DIFF
--- a/src/adafruit_blinka/microcontroller/amlogic/meson_g12_common/pin.py
+++ b/src/adafruit_blinka/microcontroller/amlogic/meson_g12_common/pin.py
@@ -142,22 +142,22 @@ if board in ("ODROID_C4", "ODROID_N2"):
     if alias is not None:
         globals()[alias + "_SCL"] = GPIOX_18
         globals()[alias + "_SDA"] = GPIOX_17
-        i2cPorts.append((int(alias[3]), GPIOX_18, GPIOX_17))
+        i2cPorts.append((int(alias[-1]), GPIOX_18, GPIOX_17))
     alias = get_dts_alias("ffd1c000.i2c")
     if alias is not None:
         globals()[alias + "_SCL"] = GPIOA_15
         globals()[alias + "_SDA"] = GPIOA_14
-        i2cPorts.append((int(alias[3]), GPIOA_15, GPIOA_14))
+        i2cPorts.append((int(alias[-1]), GPIOA_15, GPIOA_14))
     alias = get_dts_alias("fdd24000.serial")
     if alias is not None:
         globals()[alias + "_TX"] = GPIOX_12
         globals()[alias + "_RX"] = GPIOX_13
-        uartPorts.append((int(alias[3]), GPIOX_12, GPIOX_13))
+        uartPorts.append((int(alias[-1]), GPIOX_12, GPIOX_13))
     alias = get_dts_alias("fdd23000.serial")
     if alias is not None:
         globals()[alias + "_TX"] = GPIOX_6
         globals()[alias + "_RX"] = GPIOX_7
-        uartPorts.append((int(alias[3]), GPIOX_6, GPIOX_7))
+        uartPorts.append((int(alias[-1]), GPIOX_6, GPIOX_7))
 
 i2cPorts = tuple(i2cPorts)
 uartPorts = tuple(uartPorts)

--- a/src/adafruit_blinka/microcontroller/rockchip/rk3566/pin.py
+++ b/src/adafruit_blinka/microcontroller/rockchip/rk3566/pin.py
@@ -184,35 +184,35 @@ if board in ("ODROID_M1S"):
     if alias is not None:
         globals()[alias + "_SCL"] = GPIO3_B5
         globals()[alias + "_SDA"] = GPIO3_B6
-        i2cPorts.append((int(alias[3]), GPIO3_B5, GPIO3_B6))
+        i2cPorts.append((int(alias[-1]), GPIO3_B5, GPIO3_B6))
     alias = get_pwm_chipid("fdd70010.pwm")
     if alias is not None:
         globals()["PWM" + alias] = GPIO0_C0
-        pwmOuts.append(((int(alias[3]), 0), GPIO0_C0))
+        pwmOuts.append(((int(alias[-1]), 0), GPIO0_C0))
     alias = get_pwm_chipid("fdd70020.pwm")
     if alias is not None:
         globals()["PWM" + alias] = GPIO0_C1
-        pwmOuts.append(((int(alias[3]), 0), GPIO0_C1))
+        pwmOuts.append(((int(alias[-1]), 0), GPIO0_C1))
     alias = get_pwm_chipid("fdd70030.pwm")
     if alias is not None:
         globals()["PWM" + alias] = GPIO0_C2
-        pwmOuts.append(((int(alias[3]), 0), GPIO0_C2))
+        pwmOuts.append(((int(alias[-1]), 0), GPIO0_C2))
     alias = get_dts_alias("fe620000.spi")
     if alias is not None:
         globals()[alias + "_CLK"] = GPIO3_C3
         globals()[alias + "_MOSI"] = GPIO3_C1
         globals()[alias + "_MISO"] = GPIO3_C2
-        spiPorts.append((int(alias[3]), GPIO3_C3, GPIO3_C1, GPIO3_C2))
+        spiPorts.append((int(alias[-1]), GPIO3_C3, GPIO3_C1, GPIO3_C2))
     alias = get_dts_alias("fdd50000.serial")
     if alias is not None:
         globals()[alias + "_TX"] = GPIO0_C1
         globals()[alias + "_RX"] = GPIO0_C0
-        uartPorts.append((int(alias[3]), GPIO0_C1, GPIO0_C0))
+        uartPorts.append((int(alias[-1]), GPIO0_C1, GPIO0_C0))
     alias = get_dts_alias("fe6a0000.serial")
     if alias is not None:
         globals()[alias + "_TX"] = GPIO2_A4
         globals()[alias + "_RX"] = GPIO2_A3
-        uartPorts.append((int(alias[3]), GPIO2_A4, GPIO2_A3))
+        uartPorts.append((int(alias[-1]), GPIO2_A4, GPIO2_A3))
 
 i2cPorts = tuple(i2cPorts)
 pwmOuts = tuple(pwmOuts)

--- a/src/adafruit_blinka/microcontroller/rockchip/rk3568b2/pin.py
+++ b/src/adafruit_blinka/microcontroller/rockchip/rk3568b2/pin.py
@@ -90,29 +90,29 @@ if board in ("ODROID_M1"):
     if alias is not None:
         globals()[alias + "_SCL"] = GPIO3B_5
         globals()[alias + "_SDA"] = GPIO3B_6
-        i2cPorts.append((int(alias[3]), GPIO3B_5, GPIO3B_6))
+        i2cPorts.append((int(alias[-1]), GPIO3B_5, GPIO3B_6))
     alias = get_pwm_chipid("fdd70010.pwm")
     if alias is not None:
         globals()["PWM" + alias] = GPIO0C_0
-        pwmOuts.append(((int(alias[3]), 0), GPIO0C_0))
+        pwmOuts.append(((int(alias[-1]), 0), GPIO0C_0))
     alias = get_pwm_chipid("fdd70020.pwm")
     if alias is not None:
         globals()["PWM" + alias] = GPIO0C_1
-        pwmOuts.append(((int(alias[3]), 0), GPIO0C_1))
+        pwmOuts.append(((int(alias[-1]), 0), GPIO0C_1))
     alias = get_pwm_chipid("fe6f0010.pwm")
     if alias is not None:
         globals()["PWM" + alias] = GPIO3B_2
-        pwmOuts.append(((int(alias[3]), 0), GPIO3B_2))
+        pwmOuts.append(((int(alias[-1]), 0), GPIO3B_2))
     alias = get_dts_alias("fdd50000.serial")
     if alias is not None:
         globals()[alias + "_TX"] = GPIO0C_1
         globals()[alias + "_RX"] = GPIO0C_0
-        uartPorts.append((int(alias[3]), GPIO0C_1, GPIO0C_0))
+        uartPorts.append((int(alias[-1]), GPIO0C_1, GPIO0C_0))
     alias = get_dts_alias("fe650000.serial")
     if alias is not None:
         globals()[alias + "_TX"] = GPIO3D_6
         globals()[alias + "_RX"] = GPIO3D_7
-        uartPorts.append((int(alias[3]), GPIO3D_6, GPIO3D_7))
+        uartPorts.append((int(alias[-1]), GPIO3D_6, GPIO3D_7))
 
 
 i2cPorts = tuple(i2cPorts)


### PR DESCRIPTION
Character parsing index error.
Uart serial is aliased as SERIAL'X'
At the same time as fixing the error, I changed all the indexing to unify the format.