### PR TITLE
ODROID-COMMON: Support ADC pins

### DIFF
--- a/src/adafruit_blinka/board/hardkernel/odroidc4.py
+++ b/src/adafruit_blinka/board/hardkernel/odroidc4.py
@@ -53,3 +53,7 @@ D44 = pin.GPIOAO_9
 D45 = pin.GPIOAO_7
 D46 = pin.GPIOAO_8
 D47 = pin.GPIOAO_4
+
+""" ADC """
+A0 = 40
+A1 = 37

--- a/src/adafruit_blinka/board/hardkernel/odroidm1.py
+++ b/src/adafruit_blinka/board/hardkernel/odroidm1.py
@@ -51,3 +51,7 @@ I2C0_SDA = D3
 I2C0_SCL = D5
 I2C1_SDA = D27
 I2C1_SCL = D28
+
+""" ADC """
+A0 = 40
+A1 = 37

--- a/src/adafruit_blinka/board/hardkernel/odroidm1s.py
+++ b/src/adafruit_blinka/board/hardkernel/odroidm1s.py
@@ -57,3 +57,7 @@ I2C0_SDA = D3
 I2C0_SCL = D5
 I2C1_SDA = D27
 I2C1_SCL = D28
+
+""" ADC """
+A0 = 40
+A1 = 37

--- a/src/adafruit_blinka/board/hardkernel/odroidn2.py
+++ b/src/adafruit_blinka/board/hardkernel/odroidn2.py
@@ -98,3 +98,7 @@ D26 = GPIOA_12  # PIN_32
 D27 = GPIOX_19  # PIN_36
 D30 = GPIOA_14  # PIN_27
 D31 = GPIOA_15  # PIN_28
+
+""" ADC """
+A0 = 40
+A1 = 37

--- a/src/adafruit_blinka/microcontroller/amlogic/meson_g12_common/pin.py
+++ b/src/adafruit_blinka/microcontroller/amlogic/meson_g12_common/pin.py
@@ -136,6 +136,9 @@ uartPorts = [
     (1, UART1_TX, UART1_RX),
 ]
 
+# SysFS analog inputs, Ordered as analog analogInId, device, and channel
+analogIns = []
+
 board = detector.board.id
 if board in ("ODROID_C4", "ODROID_N2"):
     alias = get_dts_alias("ffd1d000.i2c")
@@ -159,5 +162,13 @@ if board in ("ODROID_C4", "ODROID_N2"):
         globals()[alias + "_RX"] = GPIOX_7
         uartPorts.append((int(alias[-1]), GPIOX_6, GPIOX_7))
 
+if board in ("ODROID_C4"):
+    analogIns.append((37, 0, 2))
+    analogIns.append((40, 0, 0))
+if board in ("ODROID_N2"):
+    analogIns.append((37, 0, 3))
+    analogIns.append((40, 0, 2))
+
+analogIns = tuple(analogIns)
 i2cPorts = tuple(i2cPorts)
 uartPorts = tuple(uartPorts)

--- a/src/adafruit_blinka/microcontroller/rockchip/rk3566/pin.py
+++ b/src/adafruit_blinka/microcontroller/rockchip/rk3566/pin.py
@@ -175,10 +175,13 @@ pwmOuts = [
 uartPorts = []
 
 # SysFS analog inputs, Ordered as analog analogInId, device, and channel
-analogIns = ((ADC_AIN3, 0, 3),)
+analogIns = [
+    (ADC_AIN3, 0, 3),
+]
 
 board = detector.board.id
 if board in ("ODROID_M1S"):
+    analogIns.append((40, 0, 2))
     alias = get_dts_alias("fe5c0000.i2c")
     if alias is not None:
         globals()[alias + "_SCL"] = GPIO3_B5
@@ -213,6 +216,7 @@ if board in ("ODROID_M1S"):
         globals()[alias + "_RX"] = GPIO2_A3
         uartPorts.append((int(alias[-1]), GPIO2_A4, GPIO2_A3))
 
+analogIns = tuple(analogIns)
 i2cPorts = tuple(i2cPorts)
 pwmOuts = tuple(pwmOuts)
 spiPorts = tuple(spiPorts)

--- a/src/adafruit_blinka/microcontroller/rockchip/rk3568b2/pin.py
+++ b/src/adafruit_blinka/microcontroller/rockchip/rk3568b2/pin.py
@@ -78,13 +78,12 @@ pwmOuts = []
 uartPorts = []
 
 # SysFS analog inputs, Ordered as analog analogInId, device, and channel
-analogIns = (
-    (ADC_AIN0, 0, 0),
-    (ADC_AIN1, 0, 0),
-)
+analogIns = []
 
 board = detector.board.id
 if board in ("ODROID_M1"):
+    analogIns.append((37, 0, 7))
+    analogIns.append((40, 0, 6))
     alias = get_dts_alias("fe5c0000.i2c")
     if alias is not None:
         globals()[alias + "_SCL"] = GPIO3B_5
@@ -113,7 +112,7 @@ if board in ("ODROID_M1"):
         globals()[alias + "_RX"] = GPIO3D_7
         uartPorts.append((int(alias[-1]), GPIO3D_6, GPIO3D_7))
 
-
+analogIns = tuple(analogIns)
 i2cPorts = tuple(i2cPorts)
 pwmOuts = tuple(pwmOuts)
 uartPorts = tuple(uartPorts)

--- a/src/analogio.py
+++ b/src/analogio.py
@@ -22,6 +22,8 @@ if detector.board.microchip_mcp2221:
 elif detector.board.greatfet_one:
     from adafruit_blinka.microcontroller.nxp_lpc4330.analogio import AnalogIn
     from adafruit_blinka.microcontroller.nxp_lpc4330.analogio import AnalogOut
+elif detector.board.any_odroid_40_pin:
+    from adafruit_blinka.microcontroller.generic_linux.sysfs_analogin import AnalogIn
 elif detector.board.any_siemens_simatic_iot2000:
     from adafruit_blinka.microcontroller.am65xx.analogio import AnalogIn
     from adafruit_blinka.microcontroller.am65xx.analogio import AnalogOut


### PR DESCRIPTION
e.g.

```
import time
import board
from analogio import AnalogIn

analog_in = AnalogIn(board.A0) # support A0 and A1.

def get_voltage(pin):
    return (pin.value * 1.8) / 1024

while True:
    print((get_voltage(analog_in),))
    time.sleep(0.1)
```