### PR TITLE
Fix ODROID_M1 board detection

### DIFF
--- a/src/microcontroller/pin.py
+++ b/src/microcontroller/pin.py
@@ -4,7 +4,7 @@
 """Pins named after their chip name."""
 
 import sys
-from adafruit_platformdetect.constants import chips as ap_chip
+from adafruit_platformdetect.constants import chips as ap_chip, boards as ap_boards
 from adafruit_blinka.agnostic import board_id, chip_id
 
 # We intentionally are patching into this namespace so skip the wildcard check.
@@ -113,7 +113,7 @@ elif chip_id == ap_chip.RK3328:
 elif chip_id == ap_chip.RK3566:
     from adafruit_blinka.microcontroller.rockchip.rk3566.pin import *
 elif chip_id == ap_chip.RK3568:
-    if board_id in ("ODROID_M1"):
+    if board_id in (ap_boards.ODROID_M1,):
         from adafruit_blinka.microcontroller.rockchip.rk3568b2.pin import *
     else:
         from adafruit_blinka.microcontroller.rockchip.rk3568.pin import *


### PR DESCRIPTION
Yep, it worked because
```python
"abc" in "abc"  # is True
```
But I guess the idea was to check if it's one of the boards (and for now the tuple of boards has only one member)

Same as:
https://github.com/adafruit/Adafruit_Blinka/blob/fde264375432951da98131182e9b00a177b2f3c1/src/microcontroller/pin.py#L27