### PR TITLE
Add support for Repka Pi-3 H5 and Pi-4 H6 boards

### DIFF
--- a/src/adafruit_blinka/board/repkapi/repka_pi_3.py
+++ b/src/adafruit_blinka/board/repkapi/repka_pi_3.py
@@ -1,0 +1,79 @@
+# SPDX-FileCopyrightText: 2024 Suren Khorenyan
+#
+# SPDX-License-Identifier: MIT
+"""Repka Pi 3 (Allwinner H5) pin names"""
+from adafruit_blinka.microcontroller.generic_linux.libgpiod_pin import Pin
+
+PA0 = Pin((1, 0))
+UART2_TX = PA0
+PA1 = Pin((1, 1))
+UART2_RX = PA1
+PA2 = Pin((1, 2))
+PA3 = Pin((1, 3))
+SPI0_CS1 = PA3
+PA4 = Pin((1, 4))
+UART0_TX = PA4
+PA5 = Pin((1, 5))
+UART0_RX = PA5
+PA6 = Pin((1, 6))
+PA7 = Pin((1, 7))
+PA8 = Pin((1, 8))
+PA9 = Pin((1, 9))
+PA10 = Pin((1, 10))
+PA11 = Pin((1, 11))
+TWI1_SCL = PA11
+PA12 = Pin((1, 12))
+TWI1_SDA = PA12
+PA13 = Pin((1, 13))
+SPI1_CS0 = PA13
+PA14 = Pin((1, 14))
+SPI1_CLK = PA14
+PA15 = Pin((1, 15))
+SPI1_MOSI = PA15
+PA16 = Pin((1, 16))
+SPI1_MISO = PA16
+PA18 = Pin((1, 18))
+TWI2_SCL = PA18
+PA19 = Pin((1, 19))
+TWI2_SDA = PA19
+PA21 = Pin((1, 21))
+
+PC0 = Pin((1, 64))
+SPI0_MOSI = PC0
+PC1 = Pin((1, 65))
+SPI0_MISO = PC1
+PC2 = Pin((1, 66))
+SPI0_CLK = PC2
+PC3 = Pin((1, 67))
+SPI0_CS0 = PC3
+
+
+PL2 = Pin((1, 354))
+S_UART_TX = PL2
+PL3 = Pin((1, 355))
+S_UART_RX = PL3
+PL11 = Pin((1, 363))
+
+
+i2cPorts = (
+    (1, TWI1_SCL, TWI1_SDA),
+    # todo: check pinout in `/proc/device-tree/repka-pinout`?
+    (2, TWI2_SCL, TWI2_SDA),
+)
+# ordered as spiId, sckId, mosiId, misoId
+spiPorts = (
+    (0, SPI0_CLK, SPI0_MOSI, SPI0_MISO),
+    (1, SPI1_CLK, SPI1_MOSI, SPI1_MISO),
+)
+# ordered as uartId, txId, rxId
+uartPorts = (
+    # todo: check uart ids
+    (0, UART0_TX, UART0_RX),
+    (2, UART2_TX, UART2_RX),
+    (1, S_UART_TX, S_UART_RX),
+)
+
+
+# default I2C
+SCL = i2cPorts[0][1]
+SDA = i2cPorts[0][2]

--- a/src/adafruit_blinka/board/repkapi/repka_pi_4.py
+++ b/src/adafruit_blinka/board/repkapi/repka_pi_4.py
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: 2021 Melissa LeBlanc-Williams for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+# copied from Allwinner H6 to be updated later
+
+"""Repka Pi 4 (Allwinner H6) Pin Names"""
+from adafruit_blinka.microcontroller.generic_linux.libgpiod_pin import Pin
+
+# TODO: check and update all pins after board release
+PC16 = Pin((1, 79))
+
+PD14 = Pin((1, 110))
+PD15 = Pin((1, 111))
+PD16 = Pin((1, 112))
+PD17 = Pin((1, 113))
+PD18 = Pin((1, 114))
+PD19 = Pin((1, 115))
+UART2_TX = PD19
+PD20 = Pin((1, 116))
+UART2_RX = PD20
+PD21 = Pin((1, 117))
+PD22 = Pin((1, 118))
+PD23 = Pin((1, 119))
+PD24 = Pin((1, 120))
+PD25 = Pin((1, 121))
+TWI0_SCL = PD25
+PD26 = Pin((1, 122))
+TWI0_SDA = PD26
+
+PG10 = Pin((1, 202))
+PG11 = Pin((1, 203))
+PG12 = Pin((1, 204))
+PG13 = Pin((1, 205))
+PG14 = Pin((1, 206))
+
+PH2 = Pin((1, 226))
+PH3 = Pin((1, 227))
+SPI1_CS = PH3
+PH4 = Pin((1, 228))
+SPI1_SCLK = PH4
+PH5 = Pin((1, 229))
+SPI1_MOSI = PH5
+PH6 = Pin((1, 230))
+SPI1_MISO = PH6
+PH8 = Pin((1, 230))
+PH9 = Pin((1, 231))
+
+PL2 = Pin((0, 2))
+PL3 = Pin((0, 3))
+PL8 = Pin((0, 8))
+PL9 = Pin((0, 9))
+PL10 = Pin((0, 10))
+
+i2cPorts = ((0, TWI0_SCL, TWI0_SDA),)
+spiPorts = ((1, SPI1_SCLK, SPI1_MOSI, SPI1_MISO),)
+uartPorts = ((2, UART2_TX, UART2_RX),)

--- a/src/board.py
+++ b/src/board.py
@@ -364,6 +364,12 @@ elif board_id == ap_board.AML_S905X_CC:
 elif board_id == ap_board.ROC_RK3328_CC:
     from adafruit_blinka.board.librecomputer.roc_rk3328_cc import *
 
+elif board_id == ap_board.REPKA_PI_3_H5:
+    from adafruit_blinka.board.repkapi.repka_pi_3 import *
+
+elif board_id == ap_board.REPKA_PI_4_H6:
+    from adafruit_blinka.board.repkapi.repka_pi_4 import *
+
 elif board_id == ap_board.GENERIC_LINUX_PC:
     from adafruit_blinka.board.generic_linux_pc import *
 

--- a/src/microcontroller/pin.py
+++ b/src/microcontroller/pin.py
@@ -4,7 +4,7 @@
 """Pins named after their chip name."""
 
 import sys
-from adafruit_platformdetect.constants import chips as ap_chip
+from adafruit_platformdetect.constants import chips as ap_chip, boards as ap_boards
 from adafruit_blinka.agnostic import board_id, chip_id
 
 # We intentionally are patching into this namespace so skip the wildcard check.
@@ -45,11 +45,17 @@ elif chip_id == ap_chip.SUN8I:
 elif chip_id == ap_chip.H3:
     from adafruit_blinka.microcontroller.allwinner.h3.pin import *
 elif chip_id == ap_chip.H5:
-    from adafruit_blinka.microcontroller.allwinner.h5.pin import *
+    if board_id == ap_boards.REPKA_PI_3_H5:
+        from adafruit_blinka.board.repkapi.repka_pi_3 import *
+    else:
+        from adafruit_blinka.microcontroller.allwinner.h5.pin import *
 elif chip_id == ap_chip.H6:
     from adafruit_blinka.microcontroller.allwinner.h6.pin import *
 elif chip_id == ap_chip.H616:
-    from adafruit_blinka.microcontroller.allwinner.h616.pin import *
+    if board_id == ap_boards.REPKA_PI_4_H6:
+        from adafruit_blinka.board.repkapi.repka_pi_4 import *
+    else:
+        from adafruit_blinka.microcontroller.allwinner.h616.pin import *
 elif chip_id == ap_chip.SAMA5:
     from adafruit_blinka.microcontroller.sama5.pin import *
 elif chip_id == ap_chip.T210:


### PR DESCRIPTION
Repka-Pi 3 H5 differs from the standard H5 pinout. Add pinout to the lib

This PR depends on another PR in the PlatformDetect library https://github.com/adafruit/Adafruit_Python_PlatformDetect/pull/336
Pipelines will stay red until PlatformDetect is updated