### PR TITLE
Corrected URL of libgpiod install script

### DIFF
--- a/src/adafruit_blinka/microcontroller/generic_linux/libgpiod_pin.py
+++ b/src/adafruit_blinka/microcontroller/generic_linux/libgpiod_pin.py
@@ -7,7 +7,7 @@ try:
 except ImportError:
     raise ImportError(
         "libgpiod Python bindings not found, please install and try again! See "
-        "https://github.com/adafruit/Raspberry-Pi-Installer-Scripts/blob/master/libgpiod.sh"
+        "https://github.com/adafruit/Raspberry-Pi-Installer-Scripts/blob/main/libgpiod.py"
     ) from ImportError
 
 # Versions 1.5.4 and earlier have no __version__ attribute


### PR DESCRIPTION
With https://github.com/adafruit/Raspberry-Pi-Installer-Scripts/commit/bc4b07e658fe287951a372df236edd62b522af97#diff-642f752e075338833f3d09557b0c3ee40d8b31041f7a478d0c24df8f71261e16 the location of the libgpiod.sh script changed.
Additionally, a libgpiod.py script appeared in https://github.com/adafruit/Raspberry-Pi-Installer-Scripts/commit/210dcee1389ab142588ec8afb1eec298982cd989 and is more maintained.
So it seems better to suggest using the latter.