### PR TITLE
libgpio 2.x support for odroid c4

### DIFF
--- a/src/adafruit_blinka/microcontroller/amlogic/meson_g12_common/pin.py
+++ b/src/adafruit_blinka/microcontroller/amlogic/meson_g12_common/pin.py
@@ -15,30 +15,13 @@ Linux kernel 5.4.y (mainline)
 from adafruit_blinka.agnostic import detector
 from adafruit_blinka.microcontroller.alias import get_dts_alias, get_pwm_chipid
 from adafruit_blinka.microcontroller.generic_linux.libgpiod_pin import Pin
+from adafruit_blinka.microcontroller.generic_linux.libgpiod_chip import Chip
 
-try:
-    import gpiod
-except ImportError:
-    raise ImportError(
-        "libgpiod Python bindings not found, please install and try again!"
-    ) from ImportError
+chip0 = Chip("0")
+chip1 = Chip("1")
 
-if hasattr(gpiod, "Chip"):
-    chip0 = gpiod.Chip("0")
-    chip1 = gpiod.Chip("1")
-else:
-    chip0 = gpiod.chip("0")
-    chip1 = gpiod.chip("1")
-
-if callable(chip0.num_lines):
-    chip0lines = chip0.num_lines()
-else:
-    chip0lines = chip0.num_lines
-
-if callable(chip1.num_lines):
-    chip1lines = chip1.num_lines()
-else:
-    chip1lines = chip1.num_lines
+chip0lines = chip0.num_lines
+chip1lines = chip1.num_lines
 
 if chip0lines < 20:
     aobus = 0

--- a/src/adafruit_blinka/microcontroller/generic_linux/libgpiod/libgpiod_chip_1_x.py
+++ b/src/adafruit_blinka/microcontroller/generic_linux/libgpiod/libgpiod_chip_1_x.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: 2021 Melissa LeBlanc-Williams for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+"""A Chip class for use with libgpiod 1.x."""
+import gpiod
+
+
+# pylint: disable=too-many-branches,too-many-statements
+class Chip:
+    """Abstraction for handling all breaking changes over the lifecycle of gpiod"""
+
+    _CONSUMER = "adafruit_blinka"
+
+    id: str = None
+    num_lines: int
+
+    def __init__(self, chip_id: str):
+        self.id = chip_id
+        if hasattr(gpiod, "Chip"):
+            self._chip = gpiod.Chip(self.id)
+        else:
+            self._chip = gpiod.chip(self.id)
+
+        if callable(self._chip.num_lines):
+            self.num_lines = self._chip.num_lines()
+        else:
+            self.num_lines = self.num_lines
+
+    def __repr__(self):
+        return self.id
+
+    def __eq__(self, other):
+        return self.id == other

--- a/src/adafruit_blinka/microcontroller/generic_linux/libgpiod/libgpiod_chip_2_x.py
+++ b/src/adafruit_blinka/microcontroller/generic_linux/libgpiod/libgpiod_chip_2_x.py
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: 2021 Melissa LeBlanc-Williams for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+"""A Chip class for use with libgpiod 2.x."""
+import gpiod
+
+
+# pylint: disable=too-many-branches,too-many-statements
+class Chip:
+    """Abstraction for handling all breaking changes over the lifecycle of gpiod"""
+
+    _CONSUMER = "adafruit_blinka"
+
+    id: str = None
+    num_lines: int
+
+    def __init__(self, chip_id: str):
+        self.id = chip_id
+        path = f"/dev/gpiochip{self.id}"
+        self._chip = gpiod.Chip(path)
+
+        info = self._chip.get_info()
+        self.num_lines = info.num_lines
+
+    def __repr__(self):
+        return self.id
+
+    def __eq__(self, other):
+        return self.id == other

--- a/src/adafruit_blinka/microcontroller/generic_linux/libgpiod_chip.py
+++ b/src/adafruit_blinka/microcontroller/generic_linux/libgpiod_chip.py
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2021 Melissa LeBlanc-Williams for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+"""A Chip class for use with libgpiod."""
+try:
+    import gpiod
+except ImportError:
+    raise ImportError(
+        "libgpiod Python bindings not found, please install and try again! See "
+        "https://github.com/adafruit/Raspberry-Pi-Installer-Scripts/blob/main/libgpiod.py"
+    ) from ImportError
+
+# Versions 1.5.4 and earlier have no __version__ attribute
+if hasattr(gpiod, "__version__"):
+    version = gpiod.__version__
+else:
+    version = "1.x"
+
+if version.startswith("1."):
+    from .libgpiod.libgpiod_chip_1_x import Chip  # pylint: disable=unused-import
+else:
+    from .libgpiod.libgpiod_chip_2_x import Chip  # pylint: disable=unused-import


### PR DESCRIPTION
After an upgrade of my python environment I got issues with libgpiod

A quick search learned me that libgpiod has been updated again with breaking changes
The same issue was already faced with RPI5 in issue https://github.com/adafruit/Adafruit_Blinka/issues/740

I much like the clean and neat approach taken with libgpiod_pin and made an attempt to mimic the same in libgpiod_chip for supporting multiple libgpiod versions on Odroid C4 (meson_g12_common).

Do note that in the past I created some regression causing issue https://github.com/adafruit/Adafruit_Blinka/issues/685
All this logic is now in libgpiod_chip.py, so I hope it didn't break anything. As @how2flow is also very active lately I hope he might also have a peak at it.

This approach could also be used Adafruit_Blinka/src/adafruit_blinka/microcontroller/amlogic/a311d/pin.py but as I can't test this I didn't touch it.