### PR TITLE
Show NotImplementedError for pwmio on the Pi 5 for now

### DIFF
--- a/src/pwmio.py
+++ b/src/pwmio.py
@@ -16,7 +16,7 @@ from adafruit_blinka.agnostic import detector
 
 # pylint: disable=unused-import
 
-if detector.board.any_raspberry_pi:
+if detector.board.any_raspberry_pi and not detector.board.RASPBERRY_PI_5:
     from adafruit_blinka.microcontroller.bcm283x.pwmio.PWMOut import PWMOut
 elif detector.board.any_coral_board:
     from adafruit_blinka.microcontroller.generic_linux.sysfs_pwmout import PWMOut


### PR DESCRIPTION
PWMIO is not working on the Pi 5 at the moment (see #776). This is more of a stopgap measure to at least show a more appropriate error until it has been fixed.