### PR TITLE
Update Blinka to use rpi-lgpio for PWM

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ if os.path.exists("/proc/device-tree/compatible"):
     ):
         board_reqs = ["RPi.GPIO", "rpi_ws281x>=4.0.0", "sysv_ipc>=1.1.0"]
     # Pi 5
-    if (b"brcm,bcm2712" in compat):
+    if b"brcm,bcm2712" in compat:
         board_reqs = ["rpi_ws281x>=4.0.0", "sysv_ipc>=1.1.0", "rpi-lgpio"]
     if (
         b"ti,am335x" in compat

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,6 @@
 
 import io
 import os
-import sys
 
 from setuptools import setup, find_packages
 
@@ -27,15 +26,18 @@ if os.path.exists("/proc/device-tree/compatible"):
         compat = f.read()
     if b"nvidia,tegra" in compat:
         board_reqs = ["Jetson.GPIO"]
+    # Pi 4 and Earlier
     if (
         b"brcm,bcm2835" in compat
         or b"brcm,bcm2836" in compat
         or b"brcm,bcm2837" in compat
         or b"brcm,bcm2838" in compat
         or b"brcm,bcm2711" in compat
-        or b"brcm,bcm2712" in compat
     ):
         board_reqs = ["RPi.GPIO", "rpi_ws281x>=4.0.0", "sysv_ipc>=1.1.0"]
+    # Pi 5
+    if (b"brcm,bcm2712" in compat):
+        board_reqs = ["rpi_ws281x>=4.0.0", "sysv_ipc>=1.1.0", "rpi-lgpio"]
     if (
         b"ti,am335x" in compat
     ):  # BeagleBone Black, Green, PocketBeagle, BeagleBone AI, etc.

--- a/src/pwmio.py
+++ b/src/pwmio.py
@@ -16,7 +16,7 @@ from adafruit_blinka.agnostic import detector
 
 # pylint: disable=unused-import
 
-if detector.board.any_raspberry_pi and not detector.board.RASPBERRY_PI_5:
+if detector.board.any_raspberry_pi:
     from adafruit_blinka.microcontroller.bcm283x.pwmio.PWMOut import PWMOut
 elif detector.board.any_coral_board:
     from adafruit_blinka.microcontroller.generic_linux.sysfs_pwmout import PWMOut


### PR DESCRIPTION
Fixes #776. This fixes PWM, by installing rpi-lgpio for the Pi 5, which is a drop-in replacement for RPi.GPIO. Then Blinka can effective make use of the code for the Pi 4 and earlier.