### PR TITLE
add support for walnutpi-1b

### DIFF
--- a/src/adafruit_blinka/board/walnutpi/__init__.py
+++ b/src/adafruit_blinka/board/walnutpi/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: 2021 Melissa LeBlanc-Williams for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+"""Board definitions from WalnutPi"""

--- a/src/adafruit_blinka/board/walnutpi/walnutpi1b.py
+++ b/src/adafruit_blinka/board/walnutpi/walnutpi1b.py
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: 2021 Melissa LeBlanc-Williams for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+"""Pin definitions for the Walnut Pi 1b ."""
+
+from adafruit_blinka.microcontroller.allwinner.h616 import pin_gpioc as pin
+
+PI8 = pin.PI8
+SDA1 = pin.PI8
+PI7 = pin.PI7
+SCL1 = pin.PI7
+PC8 = pin.PC8
+PC9 = pin.PC9
+PC11 = pin.PC11
+PI11 = pin.PI11
+PH6 = pin.PH6
+SCLK = pin.PH6
+PH7 = pin.PH7
+MOSI = pin.PH7
+PH8 = pin.PH8
+MISO = pin.PH8
+PI10 = pin.PI10
+SDA2 = pin.PI10
+PI0 = pin.PI0
+PI1 = pin.PI1
+PI2 = pin.PI2
+PI3 = pin.PI3
+PI4 = pin.PI4
+
+PI5 = pin.PI5
+TX2 = pin.PI5
+PI6 = pin.PI6
+RX2 = pin.PI6
+PC10 = pin.PC10
+PI12 = pin.PI12
+PC14 = pin.PC14
+PC15 = pin.PC15
+PH5 = pin.PH5
+CS0 = pin.PH5
+PH9 = pin.PH9
+CS1 = pin.PH9
+PI9 = pin.PI9
+SCL2 = pin.PI9
+PI16 = pin.PI16
+PI15 = pin.PI15
+PI13 = pin.PI13
+TX4 = pin.PI13
+PI14 = pin.PI14
+RX4 = pin.PI14
+
+KEY = pin.PC12
+LED = pin.PC13

--- a/src/adafruit_blinka/microcontroller/allwinner/h616/pin_gpioc.py
+++ b/src/adafruit_blinka/microcontroller/allwinner/h616/pin_gpioc.py
@@ -1,0 +1,129 @@
+# SPDX-FileCopyrightText: 2021 Melissa LeBlanc-Williams for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+"""Allwinner H616 Pin Names"""
+
+try:
+    import gpioc
+except ImportError:
+    raise ImportError(
+        "gpioc Python bindings not found, please install and try again! See "
+        "https://pypi.org/project/gpioc/"
+        "\n you can run 'pip install gpioc'"
+    ) from ImportError
+
+from gpioc.pin import Pin
+
+PC0 = Pin(64)
+SPI0_SCLK = PC0
+PC1 = Pin(65)
+PC2 = Pin(66)
+SPI0_MOSI = PC2
+PC3 = Pin(67)
+SPI0_CS0 = PC3
+PC4 = Pin(68)
+SPI0_MISO = PC4
+PC5 = Pin(69)
+PC6 = Pin(70)
+PC7 = Pin(71)
+PC8 = Pin(72)
+PC9 = Pin(73)
+PC10 = Pin(74)
+PC11 = Pin(75)
+PC12 = Pin(76)
+PC13 = Pin(77)
+PC14 = Pin(78)
+PC15 = Pin(79)
+
+PF0 = Pin(160)
+PF1 = Pin(161)
+PF2 = Pin(162)
+PF3 = Pin(163)
+PF4 = Pin(164)
+PF5 = Pin(165)
+PF6 = Pin(166)
+
+PG0 = Pin(192)
+PG1 = Pin(193)
+PG2 = Pin(194)
+PG3 = Pin(195)
+PG4 = Pin(196)
+PG5 = Pin(197)
+PG6 = Pin(198)
+PG7 = Pin(199)
+PG8 = Pin(200)
+PG9 = Pin(201)
+PG10 = Pin(202)
+PG11 = Pin(203)
+PG12 = Pin(204)
+PG13 = Pin(205)
+PG14 = Pin(206)
+PG15 = Pin(207)
+PG16 = Pin(208)
+PG17 = Pin(209)
+PG18 = Pin(210)
+PG19 = Pin(211)
+
+PH0 = Pin(224)
+PH1 = Pin(225)
+PH2 = Pin(226)
+UART5_TX = PH2
+PH3 = Pin(227)
+UART5_RX = PH3
+PH4 = Pin(228)
+TWI3_SCL = PH4
+PH5 = Pin(229)
+UART2_TX = PH5
+TWI3_SDA = PH5
+SPI1_CS0 = PH5
+PH6 = Pin(230)
+UART2_RX = PH6
+SPI1_SCLK = PH6
+PH7 = Pin(231)
+SPI1_MOSI = PH7
+PH8 = Pin(232)
+SPI1_MISO = PH8
+PH9 = Pin(233)
+SPI1_CS1 = PH9
+PH10 = Pin(234)
+
+PI0 = Pin(256)
+PI1 = Pin(257)
+PI2 = Pin(258)
+PI3 = Pin(259)
+PI4 = Pin(260)
+PI5 = Pin(261)
+PI6 = Pin(262)
+PI7 = Pin(263)
+TWI1_SCL = PI7
+PI8 = Pin(264)
+TWI1_SDA = PI8
+PI9 = Pin(265)
+TWI2_SCL = PI9
+PI10 = Pin(266)
+TWI2_SDA = PI10
+PI11 = Pin(267)
+PI12 = Pin(268)
+PI13 = Pin(269)
+UART4_TX = PI13
+PI14 = Pin(270)
+UART4_RX = PI14
+PI15 = Pin(271)
+PI16 = Pin(272)
+
+i2cPorts = (
+    (1, TWI1_SCL, TWI1_SDA),
+    (2, TWI2_SCL, TWI2_SDA),
+    (3, TWI3_SCL, TWI3_SDA),
+)
+# ordered as spiId, sckId, mosiId, misoId
+spiPorts = (
+    (0, SPI0_SCLK, SPI0_MOSI, SPI0_MISO),
+    (1, SPI1_SCLK, SPI1_MOSI, SPI1_MISO),
+)
+# ordered as uartId, txId, rxId
+uartPorts = (
+    (2, UART2_TX, UART2_RX),
+    (4, UART4_TX, UART4_RX),
+    (5, UART5_TX, UART5_RX),
+)

--- a/src/board.py
+++ b/src/board.py
@@ -388,6 +388,9 @@ elif board_id == ap_board.LICHEEPI_4A:
 elif board_id == ap_board.MILKV_DUO:
     from adafruit_blinka.board.milkv_duo import *
 
+elif board_id == ap_board.WALNUT_PI_1B:
+    from adafruit_blinka.board.walnutpi.walnutpi1b import *
+
 elif (
     "BLINKA_FORCECHIP" in os.environ
     and os.environ["BLINKA_FORCEBOARD"] == "GENERIC_AGNOSTIC_BOARD"


### PR DESCRIPTION
hello,we want to add support for the walnutpi-1b board -> [walnutpi.com](https://walnutpi.com/docs/directory)

 about the commits [add new chip file for Allwinner H616](https://github.com/adafruit/Adafruit_Blinka/commit/4373a7fd4aec0fd8ee268558662f4e6fb036b37c)
we want to give the user control over the pins occupied by the kernel driver, such as the system status LED. so we designed a python library named gpioc to control gpio by means of control registers.
We don't want to contaminate other boards that use this chip, so we create a new pin file for Allwinner H616