### PR TITLE
Add SPI, NeoPixel to "generic os-agnostic" board

### DIFF
--- a/src/adafruit_blinka/board/generic_agnostic_board.py
+++ b/src/adafruit_blinka/board/generic_agnostic_board.py
@@ -11,9 +11,11 @@ Dx_INPUT_TRUE_PULL_UP = pin.D2
 Dx_INPUT_TRUE_PULL_DOWN = pin.D3
 Dx_OUTPUT = pin.D4
 Dx_INPUT_TOGGLE = pin.D7
-# Special "digital" pins
-NEOPIXEL = pin.D6
 
+# Special digital pins for pixels
+NEOPIXEL = pin.D6
+DOTSTAR_DATA = pin.D8
+DOTSTAR_CLK = pin.D9
 
 # Analog pins
 Ax_INPUT_RAND_INT = pin.A0
@@ -32,6 +34,9 @@ SCK = pin.SCK
 MOSI = pin.MOSI
 MISO = pin.MISO
 CS = pin.D6
+
+# SPI port
+spiPorts = ((0, SCK, MOSI, MISO),)
 
 # UART pins
 UART_TX = pin.UART_TX

--- a/src/adafruit_blinka/microcontroller/generic_agnostic_board/neopixel.py
+++ b/src/adafruit_blinka/microcontroller/generic_agnostic_board/neopixel.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: MIT
 """NeoPixel write mocks for a generic board."""
 
+
 # pylint: disable=unused-argument
 def neopixel_write(gpio, buf):
     """Mocks a neopixel_write function"""

--- a/src/adafruit_blinka/microcontroller/generic_agnostic_board/neopixel.py
+++ b/src/adafruit_blinka/microcontroller/generic_agnostic_board/neopixel.py
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: 2024 Brent Rubell for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+"""NeoPixel write mocks for a generic board."""
+
+
+def neopixel_write(gpio, buf):
+    """Mocks a neopixel_write function"""
+    # pad output buffer from 3 bpp to 4 bpp
+    buffer = []
+    for i in range(0, len(buf), 3):
+        buffer.append(0)
+        buffer.append(buf[i + 2])
+        buffer.append(buf[i + 1])
+        buffer.append(buf[i])
+
+    # then, do nothing

--- a/src/adafruit_blinka/microcontroller/generic_agnostic_board/neopixel.py
+++ b/src/adafruit_blinka/microcontroller/generic_agnostic_board/neopixel.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: MIT
 """NeoPixel write mocks for a generic board."""
 
-
+# pylint: disable=unused-argument
 def neopixel_write(gpio, buf):
     """Mocks a neopixel_write function"""
     # pad output buffer from 3 bpp to 4 bpp

--- a/src/adafruit_blinka/microcontroller/generic_agnostic_board/pin.py
+++ b/src/adafruit_blinka/microcontroller/generic_agnostic_board/pin.py
@@ -204,7 +204,10 @@ A2 = Pin(9)
 A3 = Pin(10)
 A4 = Pin(12)
 
+# Special digital pins for pixels
 D7 = Pin(11)
+D8 = Pin(13)
+D9 = Pin(14)
 
 # I2C pins
 SDA = Pin()
@@ -216,6 +219,9 @@ SCK = Pin()
 MOSI = Pin()
 MISO = Pin()
 CS = Pin()
+
+spiPorts = ((0, SCK, MOSI, MISO),)
+
 
 # UART pins
 UART_TX = Pin()

--- a/src/adafruit_blinka/microcontroller/generic_agnostic_board/spi.py
+++ b/src/adafruit_blinka/microcontroller/generic_agnostic_board/spi.py
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: 2024 Brent Rubell for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+"""SPI class for a generic agnostic board."""
+# from .rp2040_u2if import rp2040_u2if
+
+
+# pylint: disable=protected-access, no-self-use
+class SPI:
+    """SPI Base Class for a generic agnostic board."""
+
+    MSB = 0
+
+    def __init__(self, index, *, baudrate=100000):
+        self._index = index
+        self._frequency = baudrate
+
+    # pylint: disable=too-many-arguments,unused-argument
+    def init(
+        self,
+        baudrate=1000000,
+        polarity=0,
+        phase=0,
+        bits=8,
+        firstbit=MSB,
+        sck=None,
+        mosi=None,
+        miso=None,
+    ):
+        """Initialize the Port"""
+        self._frequency = baudrate
+
+    # pylint: enable=too-many-arguments
+
+    @property
+    def frequency(self):
+        """Return the current frequency"""
+        return self._frequency
+
+    def write(self, buf, start=0, end=None):
+        """Write data from the buffer to SPI"""
+        pass
+
+    def readinto(self, buf, start=0, end=None, write_value=0):
+        """Read data from SPI and into the buffer"""
+        pass
+
+    # pylint: disable=too-many-arguments
+    def write_readinto(
+        self, buffer_out, buffer_in, out_start=0, out_end=None, in_start=0, in_end=None
+    ):
+        """Perform a half-duplex write from buffer_out and then
+        read data into buffer_in
+        """
+        pass

--- a/src/adafruit_blinka/microcontroller/generic_agnostic_board/spi.py
+++ b/src/adafruit_blinka/microcontroller/generic_agnostic_board/spi.py
@@ -37,15 +37,17 @@ class SPI:
         """Return the current frequency"""
         return self._frequency
 
+    # pylint: disable=unnecessary-pass
     def write(self, buf, start=0, end=None):
         """Write data from the buffer to SPI"""
         pass
 
+    # pylint: disable=unnecessary-pass
     def readinto(self, buf, start=0, end=None, write_value=0):
         """Read data from SPI and into the buffer"""
         pass
 
-    # pylint: disable=too-many-arguments
+    # pylint: disable=too-many-arguments, unnecessary-pass
     def write_readinto(
         self, buffer_out, buffer_in, out_start=0, out_end=None, in_start=0, in_end=None
     ):

--- a/src/busio.py
+++ b/src/busio.py
@@ -363,6 +363,13 @@ class SPI(Lockable):
             from adafruit_blinka.microcontroller.generic_linux.spi import SPI as _SPI
         elif detector.board.ftdi_ft2232h:
             from adafruit_blinka.microcontroller.ftdi_mpsse.mpsse.spi import SPI as _SPI
+        elif (
+            "BLINKA_FORCECHIP" in os.environ
+            and os.environ["BLINKA_FORCEBOARD"] == "GENERIC_AGNOSTIC_BOARD"
+        ):
+            from adafruit_blinka.microcontroller.generic_agnostic_board.spi import (
+                SPI as _SPI,
+            )
         else:
             from adafruit_blinka.microcontroller.generic_micropython.spi import (
                 SPI as _SPI,

--- a/src/microcontroller/pin.py
+++ b/src/microcontroller/pin.py
@@ -96,6 +96,11 @@ elif chip_id == ap_chip.BINHO:
     from adafruit_blinka.microcontroller.nova.pin import *
 elif chip_id == ap_chip.LPC4330:
     from adafruit_blinka.microcontroller.nxp_lpc4330.pin import *
+elif (
+    "BLINKA_FORCECHIP" in os.environ
+    and os.environ["BLINKA_FORCEBOARD"] == "GENERIC_AGNOSTIC_BOARD"
+):
+    from adafruit_blinka.microcontroller.generic_agnostic_board.pin import *
 elif chip_id == ap_chip.MCP2221:
     from adafruit_blinka.microcontroller.mcp2221.pin import *
 elif chip_id == ap_chip.A10:
@@ -149,11 +154,6 @@ elif "sphinx" in sys.modules:
 elif chip_id == ap_chip.GENERIC_X86:
     print("WARNING: GENERIC_X86 is not fully supported. Some features may not work.")
     from adafruit_blinka.microcontroller.generic_micropython import Pin
-elif (
-    "BLINKA_FORCECHIP" in os.environ
-    and os.environ["BLINKA_FORCEBOARD"] == "GENERIC_AGNOSTIC_BOARD"
-):
-    from adafruit_blinka.microcontroller.generic_agnostic_board.pin import *
 elif chip_id is None:
     print(
         "WARNING: chip_id == None is not fully supported. Some features may not work."

--- a/src/neopixel_write.py
+++ b/src/neopixel_write.py
@@ -11,6 +11,7 @@ Currently supported on Raspberry Pi only.
 * Author(s): ladyada
 """
 # pylint: disable=too-many-boolean-expressions
+import os
 import sys
 
 from adafruit_blinka.agnostic import detector
@@ -19,6 +20,13 @@ if detector.board.any_raspberry_pi:
     from adafruit_blinka.microcontroller.bcm283x import neopixel as _neopixel
 elif detector.board.pico_u2if:
     from adafruit_blinka.microcontroller.rp2040_u2if import neopixel as _neopixel
+elif (
+    "BLINKA_FORCECHIP" in os.environ
+    and os.environ["BLINKA_FORCEBOARD"] == "GENERIC_AGNOSTIC_BOARD"
+):
+    from adafruit_blinka.microcontroller.generic_agnostic_board import (
+        neopixel as _neopixel,
+    )
 elif (
     detector.board.feather_u2if
     or detector.board.feather_can_u2if


### PR DESCRIPTION
This pull request adds the following to get the CircuitPython NeoPixel and DotStar libraries working with the "generic os-agnostic" board:
* Mock SPI class
* Mock `neopixel_write.py`
* Adds descriptive pins for use with pixels to generic os-agnostic board pinout, `board.NEOPIXEL`, `board.DOTSTAR_DATA`, `board.DOTSTAR_CLK`
* Adds `spiPorts` to generic os-agnostic board pinout

Related: https://github.com/adafruit/Adafruit_Blinka/pull/828