### PR TITLE
Support for generic board via PlatformDetect

### DIFF
--- a/src/adafruit_blinka/board/generic_agnostic_board.py
+++ b/src/adafruit_blinka/board/generic_agnostic_board.py
@@ -11,9 +11,11 @@ Dx_INPUT_TRUE_PULL_UP = pin.D2
 Dx_INPUT_TRUE_PULL_DOWN = pin.D3
 Dx_OUTPUT = pin.D4
 Dx_INPUT_TOGGLE = pin.D7
-# Special "digital" pins
-NEOPIXEL = pin.D6
 
+# Special digital pins for pixels
+NEOPIXEL = pin.D6
+DOTSTAR_DATA = pin.D8
+DOTSTAR_CLK = pin.D9
 
 # Analog pins
 Ax_INPUT_RAND_INT = pin.A0
@@ -32,6 +34,9 @@ SCK = pin.SCK
 MOSI = pin.MOSI
 MISO = pin.MISO
 CS = pin.D6
+
+# SPI port
+spiPorts = ((0, SCK, MOSI, MISO),)
 
 # UART pins
 UART_TX = pin.UART_TX

--- a/src/adafruit_blinka/microcontroller/generic_agnostic_board/neopixel.py
+++ b/src/adafruit_blinka/microcontroller/generic_agnostic_board/neopixel.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: MIT
 """NeoPixel write mocks for a generic board."""
 
+
 # pylint: disable=unused-argument
 def neopixel_write(gpio, buf):
     """Mocks a neopixel_write function"""

--- a/src/adafruit_blinka/microcontroller/generic_agnostic_board/neopixel.py
+++ b/src/adafruit_blinka/microcontroller/generic_agnostic_board/neopixel.py
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: 2024 Brent Rubell for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+"""NeoPixel write mocks for a generic board."""
+
+
+def neopixel_write(gpio, buf):
+    """Mocks a neopixel_write function"""
+    # pad output buffer from 3 bpp to 4 bpp
+    buffer = []
+    for i in range(0, len(buf), 3):
+        buffer.append(0)
+        buffer.append(buf[i + 2])
+        buffer.append(buf[i + 1])
+        buffer.append(buf[i])
+
+    # then, do nothing

--- a/src/adafruit_blinka/microcontroller/generic_agnostic_board/neopixel.py
+++ b/src/adafruit_blinka/microcontroller/generic_agnostic_board/neopixel.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: MIT
 """NeoPixel write mocks for a generic board."""
 
-
+# pylint: disable=unused-argument
 def neopixel_write(gpio, buf):
     """Mocks a neopixel_write function"""
     # pad output buffer from 3 bpp to 4 bpp

--- a/src/adafruit_blinka/microcontroller/generic_agnostic_board/pin.py
+++ b/src/adafruit_blinka/microcontroller/generic_agnostic_board/pin.py
@@ -204,7 +204,10 @@ A2 = Pin(9)
 A3 = Pin(10)
 A4 = Pin(12)
 
+# Special digital pins for pixels
 D7 = Pin(11)
+D8 = Pin(13)
+D9 = Pin(14)
 
 # I2C pins
 SDA = Pin()
@@ -216,6 +219,9 @@ SCK = Pin()
 MOSI = Pin()
 MISO = Pin()
 CS = Pin()
+
+spiPorts = ((0, SCK, MOSI, MISO),)
+
 
 # UART pins
 UART_TX = Pin()

--- a/src/adafruit_blinka/microcontroller/generic_agnostic_board/spi.py
+++ b/src/adafruit_blinka/microcontroller/generic_agnostic_board/spi.py
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: 2024 Brent Rubell for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+"""SPI class for a generic agnostic board."""
+# from .rp2040_u2if import rp2040_u2if
+
+
+# pylint: disable=protected-access, no-self-use
+class SPI:
+    """SPI Base Class for a generic agnostic board."""
+
+    MSB = 0
+
+    def __init__(self, index, *, baudrate=100000):
+        self._index = index
+        self._frequency = baudrate
+
+    # pylint: disable=too-many-arguments,unused-argument
+    def init(
+        self,
+        baudrate=1000000,
+        polarity=0,
+        phase=0,
+        bits=8,
+        firstbit=MSB,
+        sck=None,
+        mosi=None,
+        miso=None,
+    ):
+        """Initialize the Port"""
+        self._frequency = baudrate
+
+    # pylint: enable=too-many-arguments
+
+    @property
+    def frequency(self):
+        """Return the current frequency"""
+        return self._frequency
+
+    def write(self, buf, start=0, end=None):
+        """Write data from the buffer to SPI"""
+        pass
+
+    def readinto(self, buf, start=0, end=None, write_value=0):
+        """Read data from SPI and into the buffer"""
+        pass
+
+    # pylint: disable=too-many-arguments
+    def write_readinto(
+        self, buffer_out, buffer_in, out_start=0, out_end=None, in_start=0, in_end=None
+    ):
+        """Perform a half-duplex write from buffer_out and then
+        read data into buffer_in
+        """
+        pass

--- a/src/adafruit_blinka/microcontroller/generic_agnostic_board/spi.py
+++ b/src/adafruit_blinka/microcontroller/generic_agnostic_board/spi.py
@@ -37,15 +37,17 @@ class SPI:
         """Return the current frequency"""
         return self._frequency
 
+    # pylint: disable=unnecessary-pass
     def write(self, buf, start=0, end=None):
         """Write data from the buffer to SPI"""
         pass
 
+    # pylint: disable=unnecessary-pass
     def readinto(self, buf, start=0, end=None, write_value=0):
         """Read data from SPI and into the buffer"""
         pass
 
-    # pylint: disable=too-many-arguments
+    # pylint: disable=too-many-arguments, unnecessary-pass
     def write_readinto(
         self, buffer_out, buffer_in, out_start=0, out_end=None, in_start=0, in_end=None
     ):

--- a/src/analogio.py
+++ b/src/analogio.py
@@ -63,10 +63,7 @@ elif detector.board.itsybitsy_u2if:
     from adafruit_blinka.microcontroller.rp2040_u2if.analogio import (
         AnalogIn_ItsyBitsy as AnalogIn,
     )
-elif (
-    "BLINKA_FORCECHIP" in os.environ
-    and os.environ["BLINKA_FORCEBOARD"] == "GENERIC_AGNOSTIC_BOARD"
-):
+elif detector.board.OS_AGNOSTIC_BOARD:
     from adafruit_blinka.microcontroller.generic_agnostic_board.analogio import AnalogIn
     from adafruit_blinka.microcontroller.generic_agnostic_board.analogio import (
         AnalogOut,

--- a/src/analogio.py
+++ b/src/analogio.py
@@ -9,7 +9,6 @@ Not supported by all boards.
 
 * Author(s): Carter Nelson, Melissa LeBlanc-Williams
 """
-import os
 import sys
 
 from adafruit_blinka.agnostic import detector

--- a/src/board.py
+++ b/src/board.py
@@ -17,7 +17,6 @@ __blinka__ = True
 
 
 import sys
-import os
 import adafruit_platformdetect.constants.boards as ap_board
 from adafruit_blinka.agnostic import board_id, detector
 

--- a/src/board.py
+++ b/src/board.py
@@ -388,10 +388,7 @@ elif board_id == ap_board.LICHEEPI_4A:
 elif board_id == ap_board.MILKV_DUO:
     from adafruit_blinka.board.milkv_duo import *
 
-elif (
-    "BLINKA_FORCECHIP" in os.environ
-    and os.environ["BLINKA_FORCEBOARD"] == "GENERIC_AGNOSTIC_BOARD"
-):
+elif board_id == ap_board.OS_AGNOSTIC_BOARD:
     from adafruit_blinka.board.generic_agnostic_board import *
 
 elif "sphinx" in sys.modules:

--- a/src/busio.py
+++ b/src/busio.py
@@ -9,8 +9,6 @@ See `CircuitPython:busio` in CircuitPython for more details.
 
 * Author(s): cefn
 """
-import os
-
 try:
     import threading
 except ImportError:

--- a/src/busio.py
+++ b/src/busio.py
@@ -56,10 +56,7 @@ class I2C(Lockable):
             self._i2c = _I2C(frequency=frequency)
             return
 
-        if (
-            "BLINKA_FORCECHIP" in os.environ
-            and os.environ["BLINKA_FORCEBOARD"] == "GENERIC_AGNOSTIC_BOARD"
-        ):
+        if detector.board.OS_AGNOSTIC_BOARD:
             from adafruit_blinka.microcontroller.generic_agnostic_board.i2c import (
                 I2C as _I2C,
             )
@@ -363,10 +360,7 @@ class SPI(Lockable):
             from adafruit_blinka.microcontroller.generic_linux.spi import SPI as _SPI
         elif detector.board.ftdi_ft2232h:
             from adafruit_blinka.microcontroller.ftdi_mpsse.mpsse.spi import SPI as _SPI
-        elif (
-            "BLINKA_FORCECHIP" in os.environ
-            and os.environ["BLINKA_FORCEBOARD"] == "GENERIC_AGNOSTIC_BOARD"
-        ):
+        elif detector.board.OS_AGNOSTIC_BOARD:
             from adafruit_blinka.microcontroller.generic_agnostic_board.spi import (
                 SPI as _SPI,
             )

--- a/src/busio.py
+++ b/src/busio.py
@@ -363,6 +363,13 @@ class SPI(Lockable):
             from adafruit_blinka.microcontroller.generic_linux.spi import SPI as _SPI
         elif detector.board.ftdi_ft2232h:
             from adafruit_blinka.microcontroller.ftdi_mpsse.mpsse.spi import SPI as _SPI
+        elif (
+            "BLINKA_FORCECHIP" in os.environ
+            and os.environ["BLINKA_FORCEBOARD"] == "GENERIC_AGNOSTIC_BOARD"
+        ):
+            from adafruit_blinka.microcontroller.generic_agnostic_board.spi import (
+                SPI as _SPI,
+            )
         else:
             from adafruit_blinka.microcontroller.generic_micropython.spi import (
                 SPI as _SPI,

--- a/src/digitalio.py
+++ b/src/digitalio.py
@@ -137,10 +137,7 @@ elif detector.chip.RP2040:
     from machine import Pin
 elif detector.chip.CV1800B:
     from adafruit_blinka.microcontroller.cv1800b.pin import Pin
-elif (
-    "BLINKA_FORCECHIP" in os.environ
-    and os.environ["BLINKA_FORCEBOARD"] == "GENERIC_AGNOSTIC_BOARD"
-):
+elif detector.chip.OS_AGNOSTIC:
     from adafruit_blinka.microcontroller.generic_agnostic_board.pin import Pin
 
 from adafruit_blinka import Enum, ContextManaged

--- a/src/digitalio.py
+++ b/src/digitalio.py
@@ -9,7 +9,6 @@ See `CircuitPython:digitalio` in CircuitPython for more details.
 
 * Author(s): cefn
 """
-import os
 from adafruit_blinka.agnostic import board_id, detector
 
 # pylint: disable=ungrouped-imports,wrong-import-position,unused-wildcard-import,wildcard-import

--- a/src/microcontroller/__init__.py
+++ b/src/microcontroller/__init__.py
@@ -150,10 +150,7 @@ elif chip_id == ap_chip.TH1520:
     from adafruit_blinka.microcontroller.thead.th1520 import *
 elif chip_id == ap_chip.GENERIC_X86:
     print("WARNING: GENERIC_X86 is not fully supported. Some features may not work.")
-elif (
-    "BLINKA_FORCECHIP" in os.environ
-    and os.environ["BLINKA_FORCEBOARD"] == "GENERIC_AGNOSTIC_BOARD"
-):
+elif chip_id == ap_chip.OS_AGNOSTIC:
     from adafruit_blinka.microcontroller.generic_agnostic_board import *
 elif chip_id is None:
     print(

--- a/src/microcontroller/pin.py
+++ b/src/microcontroller/pin.py
@@ -96,10 +96,7 @@ elif chip_id == ap_chip.BINHO:
     from adafruit_blinka.microcontroller.nova.pin import *
 elif chip_id == ap_chip.LPC4330:
     from adafruit_blinka.microcontroller.nxp_lpc4330.pin import *
-elif (
-    "BLINKA_FORCECHIP" in os.environ
-    and os.environ["BLINKA_FORCEBOARD"] == "GENERIC_AGNOSTIC_BOARD"
-):
+elif chip_id == ap_chip.OS_AGNOSTIC:
     from adafruit_blinka.microcontroller.generic_agnostic_board.pin import *
 elif chip_id == ap_chip.MCP2221:
     from adafruit_blinka.microcontroller.mcp2221.pin import *

--- a/src/microcontroller/pin.py
+++ b/src/microcontroller/pin.py
@@ -96,6 +96,11 @@ elif chip_id == ap_chip.BINHO:
     from adafruit_blinka.microcontroller.nova.pin import *
 elif chip_id == ap_chip.LPC4330:
     from adafruit_blinka.microcontroller.nxp_lpc4330.pin import *
+elif (
+    "BLINKA_FORCECHIP" in os.environ
+    and os.environ["BLINKA_FORCEBOARD"] == "GENERIC_AGNOSTIC_BOARD"
+):
+    from adafruit_blinka.microcontroller.generic_agnostic_board.pin import *
 elif chip_id == ap_chip.MCP2221:
     from adafruit_blinka.microcontroller.mcp2221.pin import *
 elif chip_id == ap_chip.A10:
@@ -149,11 +154,6 @@ elif "sphinx" in sys.modules:
 elif chip_id == ap_chip.GENERIC_X86:
     print("WARNING: GENERIC_X86 is not fully supported. Some features may not work.")
     from adafruit_blinka.microcontroller.generic_micropython import Pin
-elif (
-    "BLINKA_FORCECHIP" in os.environ
-    and os.environ["BLINKA_FORCEBOARD"] == "GENERIC_AGNOSTIC_BOARD"
-):
-    from adafruit_blinka.microcontroller.generic_agnostic_board.pin import *
 elif chip_id is None:
     print(
         "WARNING: chip_id == None is not fully supported. Some features may not work."

--- a/src/microcontroller/pin.py
+++ b/src/microcontroller/pin.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: MIT
 """Pins named after their chip name."""
-import os
 import sys
 from adafruit_platformdetect.constants import chips as ap_chip, boards as ap_boards
 from adafruit_blinka.agnostic import board_id, chip_id

--- a/src/neopixel_write.py
+++ b/src/neopixel_write.py
@@ -11,7 +11,6 @@ Currently supported on Raspberry Pi only.
 * Author(s): ladyada
 """
 # pylint: disable=too-many-boolean-expressions
-import os
 import sys
 
 from adafruit_blinka.agnostic import detector

--- a/src/neopixel_write.py
+++ b/src/neopixel_write.py
@@ -20,10 +20,7 @@ if detector.board.any_raspberry_pi:
     from adafruit_blinka.microcontroller.bcm283x import neopixel as _neopixel
 elif detector.board.pico_u2if:
     from adafruit_blinka.microcontroller.rp2040_u2if import neopixel as _neopixel
-elif (
-    "BLINKA_FORCECHIP" in os.environ
-    and os.environ["BLINKA_FORCEBOARD"] == "GENERIC_AGNOSTIC_BOARD"
-):
+elif detector.board.OS_AGNOSTIC_BOARD:
     from adafruit_blinka.microcontroller.generic_agnostic_board import (
         neopixel as _neopixel,
     )

--- a/src/neopixel_write.py
+++ b/src/neopixel_write.py
@@ -11,6 +11,7 @@ Currently supported on Raspberry Pi only.
 * Author(s): ladyada
 """
 # pylint: disable=too-many-boolean-expressions
+import os
 import sys
 
 from adafruit_blinka.agnostic import detector
@@ -19,6 +20,13 @@ if detector.board.any_raspberry_pi:
     from adafruit_blinka.microcontroller.bcm283x import neopixel as _neopixel
 elif detector.board.pico_u2if:
     from adafruit_blinka.microcontroller.rp2040_u2if import neopixel as _neopixel
+elif (
+    "BLINKA_FORCECHIP" in os.environ
+    and os.environ["BLINKA_FORCEBOARD"] == "GENERIC_AGNOSTIC_BOARD"
+):
+    from adafruit_blinka.microcontroller.generic_agnostic_board import (
+        neopixel as _neopixel,
+    )
 elif (
     detector.board.feather_u2if
     or detector.board.feather_can_u2if

--- a/tests/test_generic_agnostic_board_analogio.py
+++ b/tests/test_generic_agnostic_board_analogio.py
@@ -9,7 +9,7 @@ import analogio
 # Analog Outputs
 def test_Ax_OUTPUT():
     """Test analog output pin functionality."""
-    assert board.board_id == "GENERIC_AGNOSTIC_BOARD"
+    assert board.board_id == "OS_AGNOSTIC_BOARD"
     pin_out = analogio.AnalogOut(board.Ax_OUTPUT)
 
     # Test boundaries of setting the value and reading it back
@@ -76,7 +76,7 @@ sawtooth_wave = [
 
 def test_Ax_INPUT_RAND_INT():
     """Test random integer from pin Ax_INPUT_RAND_INT"""
-    assert board.board_id == "GENERIC_AGNOSTIC_BOARD"
+    assert board.board_id == "OS_AGNOSTIC_BOARD"
     pin_random = analogio.AnalogIn(board.Ax_INPUT_RAND_INT)
 
     assert isinstance(pin_random.value, int)
@@ -86,7 +86,7 @@ def test_Ax_INPUT_RAND_INT():
 
 def test_Ax_INPUT_FIXED_INT_PI():
     """Test fixed integer from pin Ax_INPUT_FIXED_INT_PI"""
-    assert board.board_id == "GENERIC_AGNOSTIC_BOARD"
+    assert board.board_id == "OS_AGNOSTIC_BOARD"
     pin_pi = analogio.AnalogIn(board.Ax_INPUT_FIXED_INT_PI)
 
     assert pin_pi.value == 31415
@@ -96,7 +96,7 @@ def test_Ax_INPUT_FIXED_INT_PI():
 
 def test_Ax_INPUT_WAVE_SINE():
     """Test sine wave from pin Ax_INPUT_WAVE_SINE"""
-    assert board.board_id == "GENERIC_AGNOSTIC_BOARD"
+    assert board.board_id == "OS_AGNOSTIC_BOARD"
     pin_sine_wave = analogio.AnalogIn(board.Ax_INPUT_WAVE_SINE)
 
     # Run through the sine wave once
@@ -112,7 +112,7 @@ def test_Ax_INPUT_WAVE_SINE():
 
 def test_Ax_INPUT_WAVE_SAW():
     """Test sawtooth wave from pin Ax_INPUT_WAVE_SAW"""
-    assert board.board_id == "GENERIC_AGNOSTIC_BOARD"
+    assert board.board_id == "OS_AGNOSTIC_BOARD"
     pin_saw_wave = analogio.AnalogIn(board.Ax_INPUT_WAVE_SAW)
 
     # Run through the sine wave once

--- a/tests/test_generic_agnostic_board_digitalio.py
+++ b/tests/test_generic_agnostic_board_digitalio.py
@@ -10,7 +10,7 @@ import digitalio
 
 def test_Dx_OUTPUT_TRUE():
     """Test digital output pin functionality."""
-    assert board.board_id == "GENERIC_AGNOSTIC_BOARD"
+    assert board.board_id == "OS_AGNOSTIC_BOARD"
     pin_out = digitalio.DigitalInOut(board.Dx_OUTPUT)
     pin_out.direction = digitalio.Direction.OUTPUT
     # Test setting the value and reading it back
@@ -26,7 +26,7 @@ def test_Dx_OUTPUT_TRUE():
 
 def test_Dx_INPUT_TRUE():
     """Test digital input pin Dx_INPUT_TRUE."""
-    assert board.board_id == "GENERIC_AGNOSTIC_BOARD"
+    assert board.board_id == "OS_AGNOSTIC_BOARD"
     pin_true = digitalio.DigitalInOut(board.Dx_INPUT_TRUE)
     pin_true.direction = digitalio.Direction.INPUT
     assert pin_true.value is True
@@ -36,7 +36,7 @@ def test_Dx_INPUT_TRUE():
 
 def test_Dx_INPUT_TRUE_PULL_DOWN():
     """Test digital input pin Dx_INPUT_TRUE w/pull down."""
-    assert board.board_id == "GENERIC_AGNOSTIC_BOARD"
+    assert board.board_id == "OS_AGNOSTIC_BOARD"
     pin_true = digitalio.DigitalInOut(board.Dx_INPUT_TRUE)
     pin_true.direction = digitalio.Direction.INPUT
     assert pin_true.value is True
@@ -48,7 +48,7 @@ def test_Dx_INPUT_TRUE_PULL_DOWN():
 
 def test_Dx_INPUT_FALSE_PULL_UP():
     """Test digital input pin Dx_INPUT_FALSE w/pull up."""
-    assert board.board_id == "GENERIC_AGNOSTIC_BOARD"
+    assert board.board_id == "OS_AGNOSTIC_BOARD"
     pin_false = digitalio.DigitalInOut(board.Dx_INPUT_FALSE)
     pin_false.direction = digitalio.Direction.INPUT
     assert pin_false.value is False
@@ -60,7 +60,7 @@ def test_Dx_INPUT_FALSE_PULL_UP():
 
 def test_Dx_INPUT_FALSE():
     """Test digital input pin Dx_INPUT_FALSE"""
-    assert board.board_id == "GENERIC_AGNOSTIC_BOARD"
+    assert board.board_id == "OS_AGNOSTIC_BOARD"
     pin_false = digitalio.DigitalInOut(board.Dx_INPUT_FALSE)
     pin_false.direction = digitalio.Direction.INPUT
     assert pin_false.value is False
@@ -70,7 +70,7 @@ def test_Dx_INPUT_FALSE():
 
 def test_Dx_INPUT_TOGGLE():
     """Test digital input pin Dx_INPUT_TOGGLE"""
-    assert board.board_id == "GENERIC_AGNOSTIC_BOARD"
+    assert board.board_id == "OS_AGNOSTIC_BOARD"
     pin_toggle = digitalio.DigitalInOut(board.Dx_INPUT_TOGGLE)
     pin_toggle.direction = digitalio.Direction.INPUT
     assert pin_toggle.value is True


### PR DESCRIPTION
This pull request:
- Supports the OS-agnostic board via PlatformDetect instead of using `FORCE_x` variables.
  - ref: https://github.com/adafruit/Adafruit_Python_PlatformDetect/pull/353
- Adds SPI, NeoPixel, and DotStar support to this board
  - Note that this work was originally in https://github.com/adafruit/Adafruit_Blinka/pull/831

Result from running pytest across this PR using the tests within `tests/`:
```
================================================================== test session starts ===================================================================
platform darwin -- Python 3.12.2, pytest-8.2.1, pluggy-1.5.0
rootdir: /Users/brentrubell/Desktop/github_brentru/Adafruit_Blinka
collected 12 items

tests/test_generic_agnostic_board_analogio.py .....                                                                                                [ 41%]
tests/test_generic_agnostic_board_digitalio.py ......                                                                                              [ 91%]
tests/test_generic_agnostic_board_i2c.py .                                                                                                         [100%]

=================================================================== 12 passed in 0.03s ===================================================================
```