### PR TITLE
Fix SPI on generic board

### DIFF
--- a/src/busio.py
+++ b/src/busio.py
@@ -442,7 +442,9 @@ class SPI(Lockable):
         elif detector.board.any_embedded_linux:
             from adafruit_blinka.microcontroller.generic_linux.spi import SPI as _SPI
         elif detector.board.OS_AGNOSTIC_BOARD:
-            from adafruit_blinka.microcontroller.generic_agnostic_board.spi import SPI as _SPI
+            from adafruit_blinka.microcontroller.generic_agnostic_board.spi import (
+                SPI as _SPI,
+            )
         else:
             from adafruit_blinka.microcontroller.generic_micropython.spi import (
                 SPI as _SPI,

--- a/src/busio.py
+++ b/src/busio.py
@@ -441,6 +441,8 @@ class SPI(Lockable):
             from adafruit_blinka.microcontroller.am65xx.pin import Pin
         elif detector.board.any_embedded_linux:
             from adafruit_blinka.microcontroller.generic_linux.spi import SPI as _SPI
+        elif detector.board.OS_AGNOSTIC_BOARD:
+            from adafruit_blinka.microcontroller.generic_agnostic_board.spi import SPI as _SPI
         else:
             from adafruit_blinka.microcontroller.generic_micropython.spi import (
                 SPI as _SPI,


### PR DESCRIPTION
Fixes SPI configuration for the generic OS board by adding extra detection to to the `busio` `configure()` method