### PR TITLE
Fix platform.machine check in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ if os.path.exists("/proc/device-tree/compatible"):
     ):  # BeagleBone Black, Green, PocketBeagle, BeagleBone AI, etc.
         board_reqs = ["Adafruit_BBIO"]
 
-if sys.platform == "linux" and platform.machine != "mips":
+if sys.platform == "linux" and platform.machine() != "mips":
     platform_reqs = ["sysv_ipc>=1.1.0"]
 
 setup(


### PR DESCRIPTION
platform.machine() is a function rather than a property. This is to address #858.