### PR TITLE
don't upload universal bdist to pypi

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,5 +35,5 @@ jobs:
         for file in $(find -not -path "./.*" -not -path "./docs*" \( -name "*.py" -o -name "*.toml" \) ); do
             sed -i -e "s/0.0.0+auto.0/${{github.event.release.tag_name}}/" $file;
         done;
-        python -m build
+        python -m build -s
         twine upload dist/*


### PR DESCRIPTION
In short, bdist (binary distributions) created from a pure python project are universal. They cannot be made to use a platform-specific tag (like linux, windows, macos, etc). This changes the release CI workflow to skip creating/uploading a bdist to PyPI.

This library has a number of dependencies conditionally required per *machine* attributes (like CPU type). But pip (or other python package managers) will not be aware of such conditional dependencies because a universal bdist do not invoke a dynamic resolution of machine-specific dependencies. Universal bdists only resolve platform-specific dependencies (python version, system OS, etc) which isn't sufficient for this library. Instead, this paradigm is better left to a sdist (source distribution) which carry dependency details per machine-specific attributes in the setup.py file.

## Additional context
I discovered this library's bdist had flaws when research a solution for #858. The discussion there led to this PR (as requested). The only workaround for the flawed bdists from PyPI was to have users invoke pip's [`--no-binary`](https://pip.pypa.io/en/stable/cli/pip_install/#cmdoption-no-binary) arg or the env var `PIP_NO_BINARY`.

Fear not Raspberry Pi users! The piwheels project is hosting their own bdists that are built (from the sdist hosted on PyPI) on a network of RPi3 and RPi4 machines each using the 32-bit RPi OS; see status info at [piwheels.org/project/adafruit-blinka](https://www.piwheels.org/project/adafruit-blinka/). The RPi OS is already setup to use the piwheels index, so no special configuration is required.