### PR TITLE
Fix MCP2221 I2C NACK Error

### DIFF
--- a/src/adafruit_blinka/microcontroller/mcp2221/mcp2221.py
+++ b/src/adafruit_blinka/microcontroller/mcp2221/mcp2221.py
@@ -248,7 +248,7 @@ class MCP2221:
         for _ in range(MCP2221_RETRY_MAX):
             status = self._i2c_status()
             if status[20] & MASK_ADDR_NACK:
-                raise RuntimeError("I2C slave address was NACK'd")
+                raise OSError("I2C slave address was NACK'd")
             usb_cmd_status = status[8]
             if usb_cmd_status == 0:
                 break

--- a/src/adafruit_blinka/microcontroller/mcp2221/mcp2221.py
+++ b/src/adafruit_blinka/microcontroller/mcp2221/mcp2221.py
@@ -360,7 +360,8 @@ class MCP2221:
             # try a write
             try:
                 self.i2c_writeto(addr, b"\x00")
-            except RuntimeError:  # no reply!
+            except OSError:  # no reply!
+                # We got a NACK, which could be correct
                 continue
             # store if success
             found.append(addr)


### PR DESCRIPTION
The MCP2221 reports a `RuntimeError` when the `i2c_scan` function encounters a failure. This differs from CircuitPython, where it throws an `OSError`. Further, [most sensor drivers with a "double-retry"](https://github.com/adafruit/Adafruit_CircuitPython_MAX1704x/pull/10/files) (see [this driver](https://github.com/adafruit/Adafruit_CircuitPython_MAX1704x/pull/10/files))  are written to catch an `OSError`, rather than a `RuntimeError`.

This PR raises an `OSError` for the MCP2221 platform where it's expected, to fix I2C devices not initializing or being scanned correctly.

I've tested it with the MCP2221 and the MAX17048 as has @tyeth 

Related:
https://github.com/adafruit/Adafruit_Wippersnapper_Python/issues/173
https://github.com/adafruit/Adafruit_Wippersnapper_Python/pull/172#issue-2360866531