### PR TITLE
Revert "don't upload universal bdist to pypi"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,5 +35,5 @@ jobs:
         for file in $(find -not -path "./.*" -not -path "./docs*" \( -name "*.py" -o -name "*.toml" \) ); do
             sed -i -e "s/0.0.0+auto.0/${{github.event.release.tag_name}}/" $file;
         done;
-        python -m build -s
+        python -m build
         twine upload dist/*


### PR DESCRIPTION
Reverts adafruit/Adafruit_Blinka#863 because of slow installs and additional requirements making this more support heavy.