### PR TITLE
Add some pinout support for Radxa Zero PWM

### DIFF
--- a/src/adafruit_blinka/microcontroller/amlogic/s905y2/pin.py
+++ b/src/adafruit_blinka/microcontroller/amlogic/s905y2/pin.py
@@ -74,6 +74,4 @@ uartPorts = (
     (4, UARTC_TX, UARTC_RX),
 )
 
-pwmOuts = (
-    ((2, 0), GPIOAO_11),
-)
+pwmOuts = (((2, 0), GPIOAO_11),)

--- a/src/adafruit_blinka/microcontroller/amlogic/s905y2/pin.py
+++ b/src/adafruit_blinka/microcontroller/amlogic/s905y2/pin.py
@@ -73,3 +73,7 @@ uartPorts = (
     (1, UARTB_TX, UARTB_RX),
     (4, UARTC_TX, UARTC_RX),
 )
+
+pwmOuts = (
+    ((2, 0), GPIOAO_11),
+)


### PR DESCRIPTION
I add some pinout support for Radxa Zero PWM.

Below I share how I found the mapping between PWM chip and GPIO numbers.

1. Check mapping between device file and GPIO number

```
$ sudo cat /sys/kernel/debug/pinctrl/ff800000.sys-ctrl:pinctrl@14-pinctrl-meson/pinmux-pins | grep pwm
pin 11 (GPIOAO_11): ff807000.pwm (GPIO UNCLAIMED) function pwm_ao_a group pwm_ao_a
```

2. Find out the chip number corresponding to the device file

```python
In [1]: from adafruit_blinka.microcontroller.alias import get_pwm_chipid

In [2]: get_pwm_chipid("ff807000.pwm")
Out[2]: 'PWM2'

In [3]: int(get_pwm_chipid("ff807000.pwm")[-1])
Out[3]: 2
```

3. Add pinout mapping to pin.py

```python
pwmOuts = (
    ((2, 0), GPIOAO_11),  # ((chip, channel), GPIO)
)
```