### PR TITLE
[Tooling] Initial implementation of stub checker

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+# compare blinka's implementation vs the stubs coming from CircuitPython's implementation
+circuitpython-stubs
+mypy

--- a/requirements-dev.txt.license
+++ b/requirements-dev.txt.license
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2021 Melissa LeBlanc-Williams for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT

--- a/test/stubtest.py
+++ b/test/stubtest.py
@@ -5,21 +5,33 @@ of running it directly, so that we can set a specific target board and whatnot. 
 makes it easier to iterate the whole src/ folder and run the tool on each and every file.
 """
 
+import os
 import sys
 from pathlib import Path
 
 from mypy import stubtest
 
 SRC = Path(__file__).parent.parent / "src"
-sys.argv = ["stubtest"] + [path.stem for path in SRC.glob("*.py")]
-
+sys.argv = [
+    "stubtest",
+    # run on all files
+    *(path.stem for path in SRC.glob("*.py")),
+    # shorter output (1 line instead of 5?) per error
+    "--concise",
+    # do not error about things on Blinka that arent on stubs
+    "--ignore-missing-stub",
+]
 
 def main() -> int:
     """Run tests and return 0 on success, 1 in error."""
-    # TODO(elpekenin): actually implement this
-    # randomly added names, is there a list anywhere that is easy to import/fetch?
-    for target in ["micropython", "rpi", "beagle", "linux"]:
-        _ = target  # do something with it (?)
+    for target in [
+        "BLINKA_OS_AGNOSTIC",
+        # add more things here ??
+    ]:
+        msg = f"Running for: {target}"
+        print(msg, "=" * len(msg), sep="\n")
+
+        os.environ["BLINKA_FORCECHIP"] = target
 
         # potentially some unittest.mock.patch or the like, to get code running
 

--- a/test/stubtest.py
+++ b/test/stubtest.py
@@ -1,0 +1,37 @@
+"""Compare Blinka's implementation vs CircuitPython's stubs.
+
+To do this, we use MyPy's stubtest... But we invoke it from this file, instead
+of running it directly, so that we can set a specific target board and whatnot. Also
+makes it easier to iterate the whole src/ folder and run the tool on each and every file.
+"""
+
+import sys
+from pathlib import Path
+
+from mypy import stubtest
+
+SRC = Path(__file__).parent.parent / "src"
+sys.argv = ["stubtest"] + [path.stem for path in SRC.glob("*.py")]
+
+
+def main() -> int:
+    """Run tests and return 0 on success, 1 in error."""
+    # TODO(elpekenin): actually implement this
+    # randomly added names, is there a list anywhere that is easy to import/fetch?
+    for target in ["micropython", "rpi", "beagle", "linux"]:
+        _ = target  # do something with it (?)
+
+        # potentially some unittest.mock.patch or the like, to get code running
+
+        # TODO(elpekenin): pass arguments to this script? eg --failfast to control
+        # whether this quitting is performed or not
+        ret = stubtest.main()
+        if ret != 0:
+            return ret
+
+    # yay, no test failed
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
As per title, just wrote a minimal (and very subject to improvements) script that will compare the actual implementation (`.py`) against the circuitpython-generated stubs (`.pyi`)

Note:
- So far, only runs against the `BLINKA_OS_AGNOSTIC` target
  - I havent tested other targets because i expect them to fail due to lack of some connected hardware, or my computer not being what blinka is being told using the `BLINKA_FORCECHIP` environment variable
- I dont know whether circuitpython's stubs (which im guessing are generated from the doc-comments on source code) are tested/validated in any way against the actual code that ends up exposed to Python's VM