### PR TITLE
Issue 365 - i2c address not being recognized

### DIFF
--- a/src/adafruit_blinka/microcontroller/generic_linux/i2c.py
+++ b/src/adafruit_blinka/microcontroller/generic_linux/i2c.py
@@ -44,9 +44,14 @@ class I2C:
         """Try to read a byte from each address, if you get an OSError
         it means the device isnt there"""
         found = []
-        for addr in range(0, 0x80):
+        # 0x00 - 0x07 and 0x78 - 0x7F reserved
+        # see https://www.i2c-bus.org/addressing
+        for addr in range(0x08, 0x78):
             try:
-                self._i2c_bus.read_byte(addr)
+                if (addr >= 0x30 and addr <= 0x37) or (addr >= 0x50 and addr <= 0x5F):
+                    self._i2c_bus.read_byte(addr)
+                else:
+                    self._i2c_bus.write_quick(addr)
             except OSError:
                 continue
             found.append(addr)

--- a/src/adafruit_blinka/microcontroller/generic_linux/i2c.py
+++ b/src/adafruit_blinka/microcontroller/generic_linux/i2c.py
@@ -48,7 +48,7 @@ class I2C:
         # see https://www.i2c-bus.org/addressing
         for addr in range(0x08, 0x78):
             try:
-                if (addr >= 0x30 and addr <= 0x37) or (addr >= 0x50 and addr <= 0x5F):
+                if (0x30 <= addr <= 0x37) or (0x50 <= addr <= 0x5F):
                     self._i2c_bus.read_byte(addr)
                 else:
                     self._i2c_bus.write_quick(addr)


### PR DESCRIPTION
With generic-linux employ the same strategy as i2cdetect. Use write_quick for addresses and devices which should support it. Use read_byte for the remainder.

Only probe non-reserved addresses.

Tested: Raspberry 4 / Raspberry 5 OS: Debian 12 Bookworm