### PR TITLE
Radxa Zero 3W: add pwm support

### DIFF
--- a/src/adafruit_blinka/board/radxa/radxazero3.py
+++ b/src/adafruit_blinka/board/radxa/radxazero3.py
@@ -63,3 +63,7 @@ TXD = D0_D1
 RXD = D0_D0
 TX = D0_D1
 RX = D0_D0
+
+# PWM
+PWM8 = D3_B1
+PWM9 = D3_B2

--- a/src/adafruit_blinka/microcontroller/rockchip/rk3566/pin.py
+++ b/src/adafruit_blinka/microcontroller/rockchip/rk3566/pin.py
@@ -241,6 +241,16 @@ if board in ("ODROID_M1S"):
         globals()[alias + "_TX"] = GPIO2_A4
         globals()[alias + "_RX"] = GPIO2_A3
         uartPorts.append((int(alias[-1]), GPIO2_A4, GPIO2_A3))
+        
+if board in ("RADXA_ZERO3"):
+    alias = get_pwm_chipid("fe6f0000.pwm")
+    if alias is not None:
+        globals()["PWM" + alias] = GPIO3_B1
+        pwmOuts.append(((int(alias[-1]), 0), GPIO3_B1))
+    alias = get_pwm_chipid("fe6f0010.pwm")
+    if alias is not None:
+        globals()["PWM" + alias] = GPIO3_B2
+        pwmOuts.append(((int(alias[-1]), 0), GPIO3_B2))
 
 analogIns = tuple(analogIns)
 i2cPorts = tuple(i2cPorts)


### PR DESCRIPTION
Add support for PWM on Radxa Zero 3 boards.
PWM8, PWM9, as the overlays for rk3566 are scarce, this works using rk3568 overlays on:
- Armbian latest
- Linux version 6.1.84-vendor-rk35xx

