### PR TITLE
Add Pi500 and CM5 Support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,10 +16,10 @@ jobs:
     - name: Translate Repo Name For Build Tools filename_prefix
       id: repo-name
       run: echo "repo-name=Adafruit-Blinka" >> $GITHUB_OUTPUT
-    - name: Set up Python 3.7
+    - name: Set up Python 3.8
       uses: actions/setup-python@v4
       with:
-        python-version: 3.7
+        python-version: 3.8
     - name: Versions
       run: |
         python3 --version

--- a/src/board.py
+++ b/src/board.py
@@ -41,13 +41,7 @@ elif board_id == ap_board.PYBOARD:
 elif board_id == ap_board.RASPBERRY_PI_PICO:
     from adafruit_blinka.board.raspberrypi.pico import *
 
-elif (
-    detector.board.RASPBERRY_PI_4B
-    or detector.board.RASPBERRY_PI_CM4
-    or detector.board.RASPBERRY_PI_CM4S
-    or detector.board.RASPBERRY_PI_400
-    or detector.board.RASPBERRY_PI_5
-):
+elif detector.board.any_raspberry_pi_4_board or detector.board.any_raspberry_pi_5_board:
     from adafruit_blinka.board.raspberrypi.raspi_4b import *
 
 elif detector.board.any_raspberry_pi_40_pin:

--- a/src/neopixel_write.py
+++ b/src/neopixel_write.py
@@ -16,7 +16,7 @@ import sys
 from adafruit_blinka.agnostic import detector, board_id
 
 if detector.board.any_raspberry_pi:
-    if board_id == "RASPBERRY_PI_5":
+    if detector.board.any_raspberry_pi_5_board:
         import adafruit_raspberry_pi5_neopixel_write as _neopixel
     else:
         from adafruit_blinka.microcontroller.bcm283x import neopixel as _neopixel

--- a/src/neopixel_write.py
+++ b/src/neopixel_write.py
@@ -13,7 +13,7 @@ Currently supported on Raspberry Pi only.
 # pylint: disable=too-many-boolean-expressions, ungrouped-imports
 import sys
 
-from adafruit_blinka.agnostic import detector, board_id
+from adafruit_blinka.agnostic import detector
 
 if detector.board.any_raspberry_pi:
     if detector.board.any_raspberry_pi_5_board:


### PR DESCRIPTION
This adds support for the Pi500, CM5, and CM5 lite. Tested on Pi500 including running Neopixels. Simplified some of the import board checks so future boards can just be added to platformdetect.

Requires https://github.com/adafruit/Adafruit_Python_PlatformDetect/pull/377.
Fixes #922. Fixes #919.