### PR TITLE
added support for orange pi 5 max

### DIFF
--- a/src/board.py
+++ b/src/board.py
@@ -143,7 +143,7 @@ elif board_id == ap_board.ORANGE_PI_4:
 elif board_id == ap_board.ORANGE_PI_4_LTS:
     from adafruit_blinka.board.orangepi.orangepi4 import *
 
-elif board_id == ap_board.ORANGE_PI_5:
+elif board_id in (ap_board.ORANGE_PI_5, ap_board.ORANGE_PI_5_MAX):
     from adafruit_blinka.board.orangepi.orangepi5 import *
 
 elif board_id == ap_board.ORANGE_PI_5_PLUS:


### PR DESCRIPTION
Added support for Orange pi 5 Max which has same pin layout as orange pi 5
depends on https://github.com/adafruit/Adafruit_Python_PlatformDetect/pull/380