### PR TITLE
update minimum python version to 3.9

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,10 +16,10 @@ jobs:
     - name: Translate Repo Name For Build Tools filename_prefix
       id: repo-name
       run: echo "repo-name=Adafruit-Blinka" >> $GITHUB_OUTPUT
-    - name: Set up Python 3.8
+    - name: Set up Python 3.11
       uses: actions/setup-python@v4
       with:
-        python-version: 3.8
+        python-version: 3.11
     - name: Versions
       run: |
         python3 --version

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,10 +8,13 @@
 # Required
 version: 2
 
+sphinx:
+  configuration: docs/conf.py
+
 build:
-  os: "ubuntu-20.04"
+  os: "ubuntu-24.04"
   tools:
-    python: "3.7"
+    python: "3.11"
 
 python:
   install:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,7 +33,7 @@ autodoc_mock_imports = [
 ]
 
 intersphinx_mapping = {
-    "python": ("https://docs.python.org/3.7", None),
+    "python": ("https://docs.python.org/3.9", None),
     "CircuitPython": ("https://circuitpython.readthedocs.io/en/latest/", None),
 }
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -95,19 +95,8 @@ todo_emit_warnings = True
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-on_rtd = os.environ.get("READTHEDOCS", None) == "True"
+html_theme = "sphinx_rtd_theme"
 
-if not on_rtd:  # only import and set the theme if we're building docs locally
-    try:
-        import sphinx_rtd_theme
-
-        html_theme = "sphinx_rtd_theme"
-        html_theme_path = [sphinx_rtd_theme.get_html_theme_path(), "."]
-    except:
-        html_theme = "default"
-        html_theme_path = ["."]
-else:
-    html_theme_path = ["."]
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,3 +3,4 @@
 # SPDX-License-Identifier: Unlicense
 
 sphinx>=4.0.0
+sphinx-rtd-theme

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setup(
     long_description_content_type="text/x-rst",
     author="Adafruit Industries",
     author_email="circuitpython@adafruit.com",
-    python_requires=">=3.7.0",
+    python_requires=">=3.9.0",
     url="https://github.com/adafruit/Adafruit_Blinka",
     package_dir={"": "src"},
     packages=find_packages("src") + ["micropython-stubs"],
@@ -109,7 +109,7 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: Implementation :: MicroPython",
     ],
 )


### PR DESCRIPTION
cc @makermelissa we discussed minimum version for Blinka and Circuitpython_Typing in the weeds during Monday's meeting a bit.  Am definitely open to input from you as well on updating it, and if you know whether there is anywhere else in this repo that it might need to be changed. 