### PR TITLE
Add support to FT4232H

### DIFF
--- a/src/adafruit_blinka/board/ftdi_ft4232h.py
+++ b/src/adafruit_blinka/board/ftdi_ft4232h.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: 2021 Melissa LeBlanc-Williams for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+"""Pin definitions for the FTDI FT4232H"""
+from adafruit_blinka.microcontroller.ftdi_mpsse.ft4232h import pin
+
+# MPSSE A
+AD4 = pin.AD4
+AD5 = pin.AD5
+AD6 = pin.AD6
+AD7 = pin.AD7
+
+SDA0 = pin.SDA0
+SCL0 = pin.SCL0
+
+SCK0 = pin.SCK0
+SCLK0 = pin.SCLK0
+MOSI0 = pin.MOSI0
+MISO0 = pin.MISO0
+
+# MPSSE B
+BD4 = pin.BD4
+BD5 = pin.BD5
+BD6 = pin.BD6
+BD7 = pin.BD7
+
+SDA1 = pin.SDA1
+SCL1 = pin.SCL1
+
+SCK1 = pin.SCK1
+SCLK1 = pin.SCLK1
+MOSI1 = pin.MOSI1
+MISO1 = pin.MISO1

--- a/src/adafruit_blinka/microcontroller/ftdi_mpsse/ft4232h/pin.py
+++ b/src/adafruit_blinka/microcontroller/ftdi_mpsse/ft4232h/pin.py
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: 2021 Melissa LeBlanc-Williams for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+"""FT4232H pin names"""
+
+from adafruit_blinka.microcontroller.ftdi_mpsse.mpsse.pin import Pin
+
+# See https://eblot.github.io/pyftdi/pinout.html for detailed FTDI device pinout information
+
+# MPSSE Port A
+AD4 = Pin(4, interface_id=0)
+AD5 = Pin(5, interface_id=0)
+AD6 = Pin(6, interface_id=0)
+AD7 = Pin(7, interface_id=0)
+
+SCL0 = Pin(interface_id=0)
+SDA0 = Pin(interface_id=0)
+SCK0 = SCLK0 = Pin(interface_id=0)
+MOSI0 = Pin(interface_id=0)
+MISO0 = Pin(interface_id=0)
+
+# MPSSE Port B
+BD4 = Pin(4, interface_id=1)
+BD5 = Pin(5, interface_id=1)
+BD6 = Pin(6, interface_id=1)
+BD7 = Pin(7, interface_id=1)
+
+SCL1 = Pin(interface_id=1)
+SDA1 = Pin(interface_id=1)
+SCK1 = SCLK1 = Pin(interface_id=1)
+MOSI1 = Pin(interface_id=1)
+MISO1 = Pin(interface_id=1)
+
+i2cPorts = (
+    (0, SCL0, SDA0),
+    (1, SCL1, SDA1),
+)
+
+spiPorts = (
+    (0, SCLK0, MOSI0, MISO0),
+    (1, SCLK1, MOSI1, MISO1),
+)

--- a/src/adafruit_blinka/microcontroller/ftdi_mpsse/mpsse/i2c.py
+++ b/src/adafruit_blinka/microcontroller/ftdi_mpsse/mpsse/i2c.py
@@ -5,7 +5,7 @@
 from adafruit_blinka.microcontroller.ftdi_mpsse.mpsse.pin import Pin
 from adafruit_blinka.microcontroller.ftdi_mpsse.mpsse.url import (
     get_ft232h_url,
-    get_ft2232h_url,
+    get_ftx232h_url,
 )
 
 
@@ -32,7 +32,7 @@ class I2C:
         if i2c_id is None:
             self._i2c.configure(get_ft232h_url(), frequency=frequency)
         else:
-            self._i2c.configure(get_ft2232h_url(i2c_id), frequency=frequency)
+            self._i2c.configure(get_ftx232h_url(i2c_id), frequency=frequency)
         Pin.mpsse_gpio = self._i2c.get_gpio()
 
     def scan(self):

--- a/src/adafruit_blinka/microcontroller/ftdi_mpsse/mpsse/pin.py
+++ b/src/adafruit_blinka/microcontroller/ftdi_mpsse/mpsse/pin.py
@@ -5,7 +5,7 @@
 
 from adafruit_blinka.microcontroller.ftdi_mpsse.mpsse.url import (
     get_ft232h_url,
-    get_ft2232h_url,
+    get_ftx232h_url,
 )
 
 
@@ -35,7 +35,7 @@ class Pin:
             if interface_id is None:
                 i2c.configure(get_ft232h_url())
             else:
-                i2c.configure(get_ft2232h_url(interface_id))
+                i2c.configure(get_ftx232h_url(interface_id))
             Pin.mpsse_gpio = i2c.get_gpio()
         # check if pin is valid
         if pin_id:

--- a/src/adafruit_blinka/microcontroller/ftdi_mpsse/mpsse/spi.py
+++ b/src/adafruit_blinka/microcontroller/ftdi_mpsse/mpsse/spi.py
@@ -5,7 +5,7 @@
 from adafruit_blinka.microcontroller.ftdi_mpsse.mpsse.pin import Pin
 from adafruit_blinka.microcontroller.ftdi_mpsse.mpsse.url import (
     get_ft232h_url,
-    get_ft2232h_url,
+    get_ftx232h_url,
 )
 
 
@@ -25,7 +25,7 @@ class SPI:
         if spi_id is None:
             self._spi.configure(get_ft232h_url())
         else:
-            self._spi.configure(get_ft2232h_url(spi_id + 1))
+            self._spi.configure(get_ftx232h_url(spi_id + 1))
         self._port = self._spi.get_port(0)
         self._port.set_frequency(100000)
         self._port._cpol = 0

--- a/src/adafruit_blinka/microcontroller/ftdi_mpsse/mpsse/url.py
+++ b/src/adafruit_blinka/microcontroller/ftdi_mpsse/mpsse/url.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: MIT
 """
 Support for getting the URL from the BLINKA_FT232H
-and BLINKA_FT2232H_{} environment variables.
+and BLINKA_FTX232H_{} environment variables.
 """
 
 import os
@@ -23,15 +23,17 @@ def get_ft232h_url():
     return "ftdi://ftdi:ft232h/1"
 
 
-def get_ft2232h_url(interface_id):
+def get_ftx232h_url(interface_id):
     """
-    Return the FTDI url to use. If BLINKA_FT2232H_{} starts with ftdi:, returns
+    Return the FTDI url to use. If BLINKA_FTX232H_{} starts with ftdi:, returns
     that. Otherwise, returns a default value.
     """
 
-    url = os.environ.get("BLINKA_FT2232H_{}".format(interface_id), "1")
+    url = os.environ.get("BLINKA_FTX232H_{}".format(interface_id), "1")
 
     if url.startswith("ftdi:"):
         return url
 
-    return "ftdi://ftdi:ft2232h/{}".format(interface_id + 1)
+    if os.environ.get("BLINKA_FT2232H", None):
+        return "ftdi://ftdi:ft2232h/{}".format(interface_id + 1)
+    return "ftdi://ftdi:ft4232h/{}".format(interface_id + 1)

--- a/src/board.py
+++ b/src/board.py
@@ -239,6 +239,9 @@ elif board_id == ap_board.FTDI_FT232H:
 elif board_id == ap_board.FTDI_FT2232H:
     from adafruit_blinka.board.ftdi_ft2232h import *
 
+elif board_id == ap_board.FTDI_FT4232H:
+    from adafruit_blinka.board.ftdi_ft4232h import *
+
 elif board_id == ap_board.BINHO_NOVA:
     from adafruit_blinka.board.binho_nova import *
 

--- a/src/busio.py
+++ b/src/busio.py
@@ -151,6 +151,8 @@ class I2C(Lockable):
                 frequency = None  # Set to None if default to avoid triggering warning
         elif detector.board.ftdi_ft2232h:
             from adafruit_blinka.microcontroller.ftdi_mpsse.mpsse.i2c import I2C as _I2C
+        elif detector.board.ftdi_ft4232h:
+            from adafruit_blinka.microcontroller.ftdi_mpsse.mpsse.i2c import I2C as _I2C
         else:
             from adafruit_blinka.microcontroller.generic_micropython.i2c import (
                 I2C as _I2C,
@@ -358,6 +360,8 @@ class SPI(Lockable):
             from adafruit_blinka.microcontroller.generic_linux.spi import SPI as _SPI
         elif detector.board.ftdi_ft2232h:
             from adafruit_blinka.microcontroller.ftdi_mpsse.mpsse.spi import SPI as _SPI
+        elif detector.board.ftdi_ft4232h:
+            from adafruit_blinka.microcontroller.ftdi_mpsse.mpsse.spi import SPI as _SPI
         elif detector.board.OS_AGNOSTIC_BOARD:
             from adafruit_blinka.microcontroller.generic_agnostic_board.spi import (
                 SPI as _SPI,
@@ -393,6 +397,10 @@ class SPI(Lockable):
                 SPI as _SPI,
             )
         elif detector.board.ftdi_ft2232h:
+            from adafruit_blinka.microcontroller.ftdi_mpsse.mpsse.spi import (
+                SPI as _SPI,
+            )
+        elif detector.board.ftdi_ft4232h:
             from adafruit_blinka.microcontroller.ftdi_mpsse.mpsse.spi import (
                 SPI as _SPI,
             )

--- a/src/digitalio.py
+++ b/src/digitalio.py
@@ -126,6 +126,8 @@ elif detector.board.ftdi_ft232h:
     from adafruit_blinka.microcontroller.ftdi_mpsse.ft232h.pin import Pin
 elif detector.board.ftdi_ft2232h:
     from adafruit_blinka.microcontroller.ftdi_mpsse.ft2232h.pin import Pin
+elif detector.board.ftdi_ft4232h:
+    from adafruit_blinka.microcontroller.ftdi_mpsse.ft4232h.pin import Pin
 elif detector.board.binho_nova:
     from adafruit_blinka.microcontroller.nova.pin import Pin
 elif detector.board.greatfet_one:

--- a/src/microcontroller/__init__.py
+++ b/src/microcontroller/__init__.py
@@ -139,6 +139,8 @@ elif chip_id == ap_chip.FT232H:
     from adafruit_blinka.microcontroller.ftdi_mpsse.ft232h import *
 elif chip_id == ap_chip.FT2232H:
     from adafruit_blinka.microcontroller.ftdi_mpsse.ft2232h import *
+elif chip_id == ap_chip.FT4232H:
+    from adafruit_blinka.microcontroller.ftdi_mpsse.ft4232h import *
 elif chip_id == ap_chip.PENTIUM_N3710:
     from adafruit_blinka.microcontroller.pentium.n3710 import *
 elif chip_id == ap_chip.ATOM_J4105:

--- a/src/microcontroller/pin.py
+++ b/src/microcontroller/pin.py
@@ -92,6 +92,8 @@ elif chip_id == ap_chip.FT232H:
     from adafruit_blinka.microcontroller.ftdi_mpsse.ft232h.pin import *
 elif chip_id == ap_chip.FT2232H:
     from adafruit_blinka.microcontroller.ftdi_mpsse.ft2232h.pin import *
+elif chip_id == ap_chip.FT4232H:
+    from adafruit_blinka.microcontroller.ftdi_mpsse.ft4232h.pin import *
 elif chip_id == ap_chip.BINHO:
     from adafruit_blinka.microcontroller.nova.pin import *
 elif chip_id == ap_chip.LPC4330:


### PR DESCRIPTION
Depends on https://github.com/adafruit/Adafruit_Python_PlatformDetect/pull/382

Non-backwards compatible changes:

- Rename BLINKA_FT2232H_x environmentr variable(s) into BLINKA_FTX232H_x
  >Perhaps acceptable since related feature is poorly documented and is only mentioned [here](https://github.com/adafruit/Adafruit_Blinka/pull/437#issuecomment-838020882).