### PR TITLE
fix compatibility with differing `/sys/bus/gpio/devices/gpiochip*`

### DIFF
--- a/src/adafruit_blinka/microcontroller/generic_linux/lgpio_pin.py
+++ b/src/adafruit_blinka/microcontroller/generic_linux/lgpio_pin.py
@@ -15,14 +15,15 @@ def _get_gpiochip():
     used for userspace GPIO access.
     """
     for dev in Path("/sys/bus/gpio/devices").glob("gpiochip*"):
-        drivers = set((dev / "of_node/compatible").read_text().split("\0"))
-        #   check if driver names are intended for userspace control
-        if drivers & {
-            "raspberrypi,rp1-gpio",
-            "raspberrypi,bcm2835-gpio",
-            "raspberrypi,bcm2711-gpio",
-        }:
-            return lgpio.gpiochip_open(int(dev.name[-1]))
+        if Path(dev / "of_node/compatible").is_file():
+            drivers = set((dev / "of_node/compatible").read_text().split("\0"))
+            #   check if driver names are intended for userspace control
+            if drivers & {
+                "raspberrypi,rp1-gpio",
+                "raspberrypi,bcm2835-gpio",
+                "raspberrypi,bcm2711-gpio",
+            }:
+                return lgpio.gpiochip_open(int(dev.name[-1]))
     # return chip0 as a fallback
     return lgpio.gpiochip_open(0)
 


### PR DESCRIPTION
When using a USB to Serial cable I note that initialising the blinka library would crash. I'd receive an error saying that it cannot open the file `/sys/bus/gpio/devices/gpiochip14/of_node/compatible`. This was because the FTDI cable had added an additional gpioChip which didn't have the expected path structure. 

I feel like it's safe to add an `is_file()` check to this path before opening and this does make the issue go away on my setup.

Please let me know if there are:

 - Coding standards I may have missed
 - Tests that I need to run and ensure I haven't broken
 - A better way to handle this

Additionally, is it worth looking if we do this sort of blind read elsewhere and fix those too? Could then add a generic function.