### PR TITLE
Only install lgpio on linux

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,5 @@ pyftdi>=0.40.0
 binho-host-adapter>=0.1.6
 adafruit-circuitpython-typing
 toml>=0.10.2; python_version<'3.11'
-lgpio>=0.2.2.0
+lgpio>=0.2.2.0; sys_platform=='linux'
 Adafruit-Blinka-Raspberry-Pi5-Neopixel; platform_machine=='aarch64'


### PR DESCRIPTION
The lgpio library requirement throws an error on Mac. (Tested with python 3.13.1 and 3.12.10).
```
Building wheels for collected packages: Adafruit-Blinka, lgpio, adafruit-circuitpython-busdevice
  Building editable for Adafruit-Blinka (pyproject.toml) ... done
  Created wheel for Adafruit-Blinka: filename=adafruit_blinka-0.0.0+auto.0-0.editable-py3-none-any.whl size=4661 sha256=bd1798a7b587b031bbc3da866084840caf91183e6e45dfef8dab344fd2990cf3
  Stored in directory: /private/var/folders/47/m_w7xs510pn0v97qjffgh_fm0000gn/T/pip-ephem-wheel-cache-x981n7gf/wheels/67/f6/2e/b77d81248a06ca1932f9729a97e3811d737fb2ae3c261c910a
  Building wheel for lgpio (pyproject.toml) ... error
  error: subprocess-exited-with-error
  
  × Building wheel for lgpio (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [15 lines of output]
      running bdist_wheel
      running build
      running build_py
      running build_ext
      building '_lgpio' extension
      swigging lgpio.i to lgpio_wrap.c
      swig -python -o lgpio_wrap.c lgpio.i
      creating build/temp.macosx-15.4-x86_64-cpython-312
      clang -fno-strict-overflow -Wsign-compare -Wunreachable-code -DNDEBUG -g -O3 -Wall -Isrc -I/Users/####/Developement/blinka/Adafruit_Blinka/venv-12/include -I/Users/####/.pyenv/versions/3.12.10/include/python3.12 -c lgpio_wrap.c -o build/temp.macosx-15.4-x86_64-cpython-312/lgpio_wrap.o
      In file included from lgpio_wrap.c:3247:
      src/lgpio.h:34:10: fatal error: 'linux/gpio.h' file not found
         34 | #include <linux/gpio.h>
            |          ^~~~~~~~~~~~~~
      1 error generated.
      error: command '/usr/bin/clang' failed with exit code 1
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
  ERROR: Failed building wheel for lgpio
```