### PR TITLE
include adafruit_blinka package in build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ py-modules = [
 [tool.setuptools.packages.find]
 where = ["src"]
 include = [
+    "adafruit_blinka",
     "adafruit_blinka.microcontroller.bcm283x.libgpiod_pulsein*",
     "adafruit_blinka.microcontroller.amlogic.meson_g12_common.pulseio.libgpiod_pulsein*",
     "*.pyi"


### PR DESCRIPTION
I think this resolves: #975 

with this change I tested locally by doing `pip install .` and then going to the REPL and I can now successfully run `import digitalio` 

All testing was ubuntu 24.04 under python 3.12

Perhaps this makes the items that follow it in the packages list redundant though? Maybe those could be removed, I didn't try it, and they look potentially hardware dependent so I'm not sure how to test if we do remove them.