### PR TITLE
dont require lgpio on python 3.13+

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,5 @@ pyftdi>=0.40.0
 binho-host-adapter>=0.1.6
 adafruit-circuitpython-typing
 toml>=0.10.2; python_version<'3.11'
-lgpio>=0.2.2.0; sys_platform=='linux'
+lgpio>=0.2.2.0; sys_platform=='linux' and python_version<'3.13'
 Adafruit-Blinka-Raspberry-Pi5-Neopixel; platform_machine=='aarch64'


### PR DESCRIPTION
I did a quick test and confirmed that this allows adafruit-blinka to be installed under py3.13. I assume the actual gpio functionality on rp5 would not work in that environment, but installing blinka and importing modules seems to and that should be good enough for our docs builds I believe. 