### PR TITLE
Add the microcontroller module to the packages list

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ include = [
     "adafruit_blinka",
     "adafruit_blinka.microcontroller.bcm283x.libgpiod_pulsein*",
     "adafruit_blinka.microcontroller.amlogic.meson_g12_common.pulseio.libgpiod_pulsein*",
+    "microcontroller",
     "*.pyi"
 ]
 


### PR DESCRIPTION
It is missing, due to previously being found with the package find I believe.
This leads to an exception when trying to import it, but also modules that depend on it on some platforms.
This is on a Pi 3:
```py
$ python blinkatest.py
Hello, blinka!
Digital IO ok!
Traceback (most recent call last):
  File "/home/pi/temp/blinkatest.py", line 12, in <module>
    i2c = busio.I2C(board.SCL, board.SDA)
  File "/home/pi/temp/venv-13/lib/python3.13/site-packages/busio.py", line 36, in __init__
    self.init(scl, sda, frequency)
    ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^
  File "/home/pi/temp/venv-13/lib/python3.13/site-packages/busio.py", line 167, in init
    from microcontroller.pin import i2cPorts
ModuleNotFoundError: No module named 'microcontroller'
```
It is the only top level package along with `adafruit_blinka` so maybe that should be all that was missing.
I still don't know exactly how the original syntax worked and how this one does.
Would it be ok to use `"*"` instead for future proofing ?