### PR TITLE
Don't install lgpio for Python >= 3.13

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ if os.path.exists("/proc/device-tree/compatible"):
     elif b"brcm,bcm2712" in compat:
         board_reqs = [
             "rpi_ws281x>=4.0.0",
-            "lgpio",
+            "lgpio;python_version<'3.11'",
             "Adafruit-Blinka-Raspberry-Pi5-Neopixel",
         ]
     # Pi 4 and Earlier


### PR DESCRIPTION
This change was originally done in #977, but when reverting, I missed it. I caught it while testing.