### PR TITLE
Fix RTD error, README badge

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,6 +8,9 @@
 # Required
 version: 2
 
+sphinx:
+  configuration: docs/conf.py
+
 build:
   os: "ubuntu-20.04"
   tools:

--- a/README.rst
+++ b/README.rst
@@ -9,8 +9,8 @@ Introduction
     :target: https://adafru.it/discord
     :alt: Discord
 
-.. image:: https://travis-ci.com/adafruit/Adafruit_Blinka.svg?branch=master
-    :target: https://travis-ci.com/adafruit/Adafruit_Blinka
+.. image:: https://github.com/adafruit/Adafruit_Blinka.svg/workflows/Build%20CI/badge.svg
+    :target: https://github.com/adafruit/Adafruit_Blinka/actions
     :alt: Build Status
 
 .. image:: https://img.shields.io/badge/code%20style-black-000000.svg


### PR DESCRIPTION
- Should fix the failed ReadTheDocs builds, resulting from the missing `sphinx.configuration` key
- Fixes the broken build status badge by changing it to the GitHub Actions workflow status