### PR TITLE
Detect gpiochip via libgpiod for H616

### DIFF
--- a/src/adafruit_blinka/microcontroller/allwinner/h616/pin.py
+++ b/src/adafruit_blinka/microcontroller/allwinner/h616/pin.py
@@ -1,15 +1,22 @@
 # SPDX-FileCopyrightText: 2021 Melissa LeBlanc-Williams for Adafruit Industries
 #
 # SPDX-License-Identifier: MIT
-
 """Allwinner H616 Pin Names"""
+import glob
+import gpiod
 from adafruit_blinka.microcontroller.generic_linux.libgpiod_pin import Pin
 
-__chip_num = 1
-with open("/sys/class/gpio/gpiochip0/label", "r") as f:
-    label = f.read().strip()
-    if label == "300b000.pinctrl":
-        __chip_num = 0
+def find_gpiochip_number(target_label):
+    """Return the GPIO chip number for the target label, or 0 if not found."""
+    for dev in glob.glob("/dev/gpiochip*"):
+        with gpiod.Chip(dev) as chip:
+            info = chip.get_info()
+            if info.label == target_label:
+                return int(dev[-1])
+    return 0
+
+__chip_num = find_gpiochip_number("300b000.pinctrl")
+
 PC0 = Pin((__chip_num, 64))
 SPI0_SCLK = PC0
 PC1 = Pin((__chip_num, 65))

--- a/src/adafruit_blinka/microcontroller/allwinner/h616/pin.py
+++ b/src/adafruit_blinka/microcontroller/allwinner/h616/pin.py
@@ -6,6 +6,7 @@ import glob
 import gpiod
 from adafruit_blinka.microcontroller.generic_linux.libgpiod_pin import Pin
 
+
 def find_gpiochip_number(target_label):
     """Return the GPIO chip number for the target label, or 0 if not found."""
     for dev in glob.glob("/dev/gpiochip*"):
@@ -14,6 +15,7 @@ def find_gpiochip_number(target_label):
             if info.label == target_label:
                 return int(dev[-1])
     return 0
+
 
 __chip_num = find_gpiochip_number("300b000.pinctrl")
 


### PR DESCRIPTION
Use python3-libgpiod to scan /dev/gpiochip* and match each chip’s label, replacing the sysfs-only lookup. This ensures reliable detection on H616 and adds support for Orange Pi SBCs where the old method failed.