### PR TITLE
Make micropython.const accept any constant type

### DIFF
--- a/src/micropython-stubs/__init__.pyi
+++ b/src/micropython-stubs/__init__.pyi
@@ -11,8 +11,9 @@
 from typing import Callable, TypeVar, Any, NoReturn
 
 Fun = TypeVar("Fun", bound=Callable[..., Any])
+T = TypeVar("T")
 
-def const[T](x: T) -> T:
+def const(x: T) -> T:
     "Emulate making a constant"
 
 def native(f: Fun) -> Fun:

--- a/src/micropython-stubs/__init__.pyi
+++ b/src/micropython-stubs/__init__.pyi
@@ -12,7 +12,7 @@ from typing import Callable, TypeVar, Any, NoReturn
 
 Fun = TypeVar("Fun", bound=Callable[..., Any])
 
-def const(x: int) -> int:
+def const[T](x: T) -> T:
     "Emulate making a constant"
 
 def native(f: Fun) -> Fun:


### PR DESCRIPTION
`micropython.const` now supports any constant type, not just `int` (https://github.com/micropython/micropython/pull/8548). This updates the type checking to reflect this. This also updates the name of the file so that type checkers can find it.

This was discussed in https://github.com/adafruit/circuitpython/issues/10484.