### PR TITLE
Update Raspberry Pi Dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,11 @@ from setuptools import setup, find_packages
 
 here = os.path.abspath(os.path.dirname(__file__))
 
+
+def yellow_text(text: str) -> str:
+    return f"\033[33m{text}\033[0m"
+
+
 # Import the README and use it as the long-description.
 # Note: this will only work if 'README.md' is present in your MANIFEST.in file!
 with io.open(os.path.join(here, "README.rst"), encoding="utf-8") as f:
@@ -28,28 +33,29 @@ if not glob.glob("//usr//include//python3.*//Python.h"):
     )
 
 board_reqs = []
+raspberry_pi = False
 if os.path.exists("/proc/device-tree/compatible"):
     with open("/proc/device-tree/compatible", "rb") as f:
         compat = f.read()
     # Jetson Nano, TX2, Xavier, etc
     if b"nvidia,tegra" in compat:
         board_reqs = ["Jetson.GPIO"]
-    # Pi 5
-    elif b"brcm,bcm2712" in compat:
-        board_reqs = [
-            "rpi_ws281x>=4.0.0",
-            "lgpio;python_version<'3.11'",
-            "Adafruit-Blinka-Raspberry-Pi5-Neopixel",
-        ]
-    # Pi 4 and Earlier
+    # Pi 5 and Earlier
     elif (
         b"brcm,bcm2835" in compat
         or b"brcm,bcm2836" in compat
         or b"brcm,bcm2837" in compat
         or b"brcm,bcm2838" in compat
         or b"brcm,bcm2711" in compat
+        or b"brcm,bcm2712" in compat
     ):
-        board_reqs = ["RPi.GPIO", "rpi_ws281x>=4.0.0"]
+        board_reqs = [
+            "rpi_ws281x>=4.0.0",
+            "lgpio;python_version<'3.13'",
+            "RPi.GPIO",
+            "Adafruit-Blinka-Raspberry-Pi5-Neopixel",
+        ]
+        raspberry_pi = True
     # BeagleBone Black, Green, PocketBeagle, BeagleBone AI, etc.
     elif b"ti,am335x" in compat:
         board_reqs = ["Adafruit_BBIO"]
@@ -120,3 +126,10 @@ setup(
         "Programming Language :: Python :: Implementation :: MicroPython",
     ],
 )
+
+if raspberry_pi and os.sys.version_info >= (3, 13):
+    print(
+        yellow_text(
+            "\n*** Raspberry Pi 5 and later: lgpio will need to be installed manually. See the lgpio homepage for more details: http://abyz.me.uk/lg/download.html ***"
+        )
+    )


### PR DESCRIPTION
This combines the Pi 4 and Pi 5 dependencies. Updates the version to install lgpio to versions < 3.13 and gives a warning at the end to install lgpio manually if the version is 3.13 or later in yellow text.

Fixes #999.