### PR TITLE
Rollback breaking libgpiod changes from #1001

### DIFF
--- a/src/adafruit_blinka/microcontroller/generic_linux/libgpiod/libgpiod_pin_2_x.py
+++ b/src/adafruit_blinka/microcontroller/generic_linux/libgpiod/libgpiod_pin_2_x.py
@@ -48,8 +48,14 @@ class Pin:
         """Initialize the Pin"""
         # Input,
         if not self._line_request:
-            line_config = gpiod.LineSettings()
+            self._line_request = self._chip.request_lines(
+                config={int(self._num): None},
+                consumer=self._CONSUMER,
+            )
+            # print("init line: ", self.id, self._line)
 
+        if mode is not None:
+            line_config = gpiod.LineSettings()
             if mode == self.IN:
                 line_config.direction = gpiod.line.Direction.INPUT
                 if pull is not None:
@@ -62,18 +68,24 @@ class Pin:
                     else:
                         raise RuntimeError(f"Invalid pull for pin: {self.id}")
 
+                self._mode = self.IN
+                self._line_request.reconfigure_lines(
+                    {
+                        int(self._num): line_config,
+                    }
+                )
             elif mode == self.OUT:
                 if pull is not None:
                     raise RuntimeError("Cannot set pull resistor on output")
+                self._mode = self.OUT
                 line_config.direction = gpiod.line.Direction.OUTPUT
-
+                self._line_request.reconfigure_lines(
+                    {
+                        int(self._num): line_config,
+                    }
+                )
             else:
-                raise RuntimeError(f"Invalid mode for pin: {self.id}")
-
-            self._line_request = self._chip.request_lines(
-                {int(self._num): line_config},
-                consumer=self._CONSUMER,
-            )
+                raise RuntimeError("Invalid mode for pin: %s" % self.id)
 
     def value(self, val=None):
         """Set or return the Pin Value"""


### PR DESCRIPTION
The libgpiod changes in #1001 caused digitalio to be unable to change a pin from input to output (or vice versa) once configured. This undos those changes.