### PR TITLE
docs: add `python3-dev` to `build.apt_packages` in RTD config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -15,6 +15,8 @@ build:
   os: "ubuntu-20.04"
   tools:
     python: "3.7"
+  apt_packages:
+    - python3-dev
 
 python:
   install:


### PR DESCRIPTION
Hopefully this fixes the RTD builds