### PR TITLE
Add in_waiting property to busio.UART

### DIFF
--- a/src/adafruit_blinka/microcontroller/rp2040/uart.py
+++ b/src/adafruit_blinka/microcontroller/rp2040/uart.py
@@ -50,3 +50,8 @@ class UART:
     def write(self, buf):
         """Write to the UART from a buffer"""
         return self._uart.write(buf)
+
+    @property
+    def in_waiting(self):
+        """The number of bytes in the input buffer, available to be read"""
+        return self._uart.any()

--- a/src/busio.py
+++ b/src/busio.py
@@ -628,3 +628,14 @@ class UART(Lockable):
     def write(self, buf):
         """Write to the UART from a buffer"""
         return self._uart.write(buf)
+
+    @property
+    def in_waiting(self):
+        """The number of bytes in the input buffer, available to be read"""
+        # Custom UART implementations (e.g. RP2040) that provide in_waiting directly
+        if hasattr(self._uart, "in_waiting"):
+            return self._uart.in_waiting
+        # MicroPython's machine.UART uses any() for the same purpose
+        if hasattr(self._uart, "any"):
+            return self._uart.any()
+        raise NotImplementedError("in_waiting not supported on this platform")


### PR DESCRIPTION
## Summary

Adds the `in_waiting` property to `busio.UART` to match CircuitPython's API. Returns the number of bytes available in the input buffer.

This is needed by libraries like [Adafruit_CircuitPython_GPS](https://github.com/adafruit/Adafruit_CircuitPython_GPS) that rely on `in_waiting` to check for available data before reading.

### Changes

| File | What changed |
|------|-------------|
| `src/busio.py` | Added `in_waiting` property with fallback chain: custom `in_waiting` → MicroPython `any()` → `NotImplementedError` |
| `src/adafruit_blinka/microcontroller/rp2040/uart.py` | Added `in_waiting` property wrapping MicroPython's `uart.any()` |

### How it works

- **RP2040** (and future custom UART classes): Uses the `in_waiting` property on the underlying UART implementation
- **Generic MicroPython boards**: Falls back to `uart.any()` which is MicroPython's equivalent
- **Unsupported platforms**: Raises `NotImplementedError` with a clear message

Fixes #1046