### PR TITLE
Remove Python 3.13 version cap on lgpio dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,10 +17,6 @@ from setuptools import setup, find_packages
 here = os.path.abspath(os.path.dirname(__file__))
 
 
-def yellow_text(text: str) -> str:
-    return f"\033[33m{text}\033[0m"
-
-
 # Import the README and use it as the long-description.
 # Note: this will only work if 'README.md' is present in your MANIFEST.in file!
 with io.open(os.path.join(here, "README.rst"), encoding="utf-8") as f:
@@ -33,7 +29,6 @@ if not glob.glob("//usr//include//python3.*//Python.h"):
     )
 
 board_reqs = []
-raspberry_pi = False
 if os.path.exists("/proc/device-tree/compatible"):
     with open("/proc/device-tree/compatible", "rb") as f:
         compat = f.read()
@@ -51,11 +46,10 @@ if os.path.exists("/proc/device-tree/compatible"):
     ):
         board_reqs = [
             "rpi_ws281x>=4.0.0",
-            "lgpio;python_version<'3.13'",
+            "lgpio>=0.2.2.0",
             "RPi.GPIO",
             "Adafruit-Blinka-Raspberry-Pi5-Neopixel",
         ]
-        raspberry_pi = True
     # BeagleBone Black, Green, PocketBeagle, BeagleBone AI, etc.
     elif b"ti,am335x" in compat:
         board_reqs = ["Adafruit_BBIO"]
@@ -130,10 +124,3 @@ setup(
         "Programming Language :: Python :: Implementation :: MicroPython",
     ],
 )
-
-if raspberry_pi and os.sys.version_info >= (3, 13):
-    print(
-        yellow_text(
-            "\n*** Raspberry Pi 5 and later: lgpio will need to be installed manually. See the lgpio homepage for more details: http://abyz.me.uk/lg/download.html ***"
-        )
-    )


### PR DESCRIPTION
## Problem

`setup.py` pinned lgpio to `python_version<'3.13'`, which meant `pip install adafruit-blinka` on Python 3.13+ would skip lgpio entirely, breaking GPIO on Raspberry Pi 5.

On 3.13, the post-install message told users to install lgpio manually, but the upstream source tarball fails to build without `swig` and `liblgpio` — so most users hit a dead end.

Fixes #1016

## Changes

- **`lgpio;python_version<'3.13'`** → **`lgpio>=0.2.2.0`** — installs on all Python versions
- Pin `>=0.2.2.0` to skip the broken empty stub (`0.0.0.2`) on piwheels
- Remove unused `yellow_text()` function and `raspberry_pi` variable
- Remove post-install warning about manual lgpio installation

The lgpio dependency is only included when running on Raspberry Pi hardware (guarded by `/proc/device-tree/compatible` check), so this has no effect on non-Pi platforms.

## Pre-built wheels

Since there are no aarch64 lgpio wheels on PyPI, pre-built statically linked wheels for Python 3.13 and 3.14 are now available at:
https://github.com/adafruit/lgpio-python-wheels

Users in a venv with `--system-site-packages` will pick up the apt-installed `python3-lgpio` automatically.

## Testing

Tested on Raspberry Pi 5 (aarch64, Python 3.13.5, Raspberry Pi OS Trixie):
- ✅ `pip install` in `--system-site-packages` venv — picks up apt lgpio 0.2.2.0
- ✅ Full Blinka install completes with all dependencies
- ✅ `lgpio.gpiochip_open(0)` works (pinctrl-rp1, 54 lines)