### PR TITLE
Add helpful message when lgpio is not installed on Raspberry Pi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,9 +44,20 @@ if os.path.exists("/proc/device-tree/compatible"):
         or b"brcm,bcm2711" in compat
         or b"brcm,bcm2712" in compat
     ):
+        lgpio_req = "lgpio>=0.2.2.0"
+        try:
+            import lgpio
+        except ImportError:
+            print(
+                "\n*** lgpio is not installed. On Raspberry Pi OS, install it with:\n"
+                "    sudo apt-get install -y python3-lgpio\n"
+                "  Then recreate your virtual environment with --system-site-packages\n"
+                "  or install the wheel from:\n"
+                "    https://github.com/adafruit/lgpio-python-wheels\n"
+            )
         board_reqs = [
             "rpi_ws281x>=4.0.0",
-            "lgpio>=0.2.2.0",
+            lgpio_req,
             "RPi.GPIO",
             "Adafruit-Blinka-Raspberry-Pi5-Neopixel",
         ]


### PR DESCRIPTION
Follow-up to #1107.

When installing Blinka on a Raspberry Pi where lgpio is not already available, this prints a helpful message directing users to either:

- Install via apt: `sudo apt-get install -y python3-lgpio`
- Use pre-built wheels from [adafruit/lgpio-python-wheels](https://github.com/adafruit/lgpio-python-wheels)

Without this, users in a clean venv (no `--system-site-packages`) would see a cryptic swig build failure when pip tries to compile lgpio from the source tarball.

The lgpio dependency is still listed in `install_requires`, so pip will still attempt to resolve it — this just ensures users get clear guidance on the easy fix if it's not already installed.