### PR TITLE
Ensure libgpiod resources are cleaned up on exit

### DIFF
--- a/src/adafruit_blinka/microcontroller/amlogic/a311d/pulseio/PulseIn.py
+++ b/src/adafruit_blinka/microcontroller/amlogic/a311d/pulseio/PulseIn.py
@@ -7,6 +7,7 @@ import subprocess
 import os
 import atexit
 import random
+import signal
 import struct
 import sysv_ipc
 
@@ -29,6 +30,18 @@ def final():
 
 
 atexit.register(final)
+
+
+def _signal_handler(signum, frame):  # pylint: disable=unused-argument
+    """Handle SIGTERM/SIGINT to ensure cleanup runs"""
+    final()
+    raise SystemExit(1)
+
+
+try:
+    signal.signal(signal.SIGTERM, _signal_handler)
+except (OSError, ValueError):
+    pass  # Not all environments allow signal handling
 
 
 # pylint: disable=c-extension-no-member
@@ -108,14 +121,26 @@ class PulseIn:
 
     # pylint: enable=redefined-builtin
 
+    def __del__(self):
+        self.deinit()
+
     def deinit(self):
         """Deinitialises the PulseIn and releases any hardware and software
         resources for reuse."""
         # Clean up after ourselves
-        self._process.terminate()
-        procs.remove(self._process)
-        self._mq.remove()
-        queues.remove(self._mq)
+        if self._process is not None:
+            self._process.terminate()
+            if self._process in procs:
+                procs.remove(self._process)
+            self._process = None
+        if self._mq is not None:
+            try:
+                self._mq.remove()
+            except sysv_ipc.ExistentialError:
+                pass  # Already removed
+            if self._mq in queues:
+                queues.remove(self._mq)
+            self._mq = None
 
     def __enter__(self):
         """No-op used by Context Managers."""

--- a/src/adafruit_blinka/microcontroller/amlogic/meson_g12_common/pulseio/PulseIn.py
+++ b/src/adafruit_blinka/microcontroller/amlogic/meson_g12_common/pulseio/PulseIn.py
@@ -7,6 +7,7 @@ import subprocess
 import os
 import atexit
 import random
+import signal
 import sysv_ipc
 
 DEBUG = False
@@ -28,6 +29,18 @@ def final():
 
 
 atexit.register(final)
+
+
+def _signal_handler(signum, frame):  # pylint: disable=unused-argument
+    """Handle SIGTERM/SIGINT to ensure cleanup runs"""
+    final()
+    raise SystemExit(1)
+
+
+try:
+    signal.signal(signal.SIGTERM, _signal_handler)
+except (OSError, ValueError):
+    pass  # Not all environments allow signal handling
 
 
 # pylint: disable=c-extension-no-member
@@ -110,14 +123,26 @@ class PulseIn:
 
     # pylint: enable=redefined-builtin
 
+    def __del__(self):
+        self.deinit()
+
     def deinit(self):
         """Deinitialises the PulseIn and releases any hardware and software
         resources for reuse."""
         # Clean up after ourselves
-        self._process.terminate()
-        procs.remove(self._process)
-        self._mq.remove()
-        queues.remove(self._mq)
+        if self._process is not None:
+            self._process.terminate()
+            if self._process in procs:
+                procs.remove(self._process)
+            self._process = None
+        if self._mq is not None:
+            try:
+                self._mq.remove()
+            except sysv_ipc.ExistentialError:
+                pass  # Already removed
+            if self._mq in queues:
+                queues.remove(self._mq)
+            self._mq = None
 
     def __enter__(self):
         """No-op used by Context Managers."""

--- a/src/adafruit_blinka/microcontroller/bcm283x/pulseio/PulseIn.py
+++ b/src/adafruit_blinka/microcontroller/bcm283x/pulseio/PulseIn.py
@@ -7,6 +7,7 @@ import subprocess
 import os
 import atexit
 import random
+import signal
 import struct
 import sysv_ipc
 
@@ -29,6 +30,18 @@ def final():
 
 
 atexit.register(final)
+
+
+def _signal_handler(signum, frame):  # pylint: disable=unused-argument
+    """Handle SIGTERM/SIGINT to ensure cleanup runs"""
+    final()
+    raise SystemExit(1)
+
+
+try:
+    signal.signal(signal.SIGTERM, _signal_handler)
+except (OSError, ValueError):
+    pass  # Not all environments allow signal handling
 
 
 # pylint: disable=c-extension-no-member
@@ -112,14 +125,26 @@ class PulseIn:
 
     # pylint: enable=redefined-builtin
 
+    def __del__(self):
+        self.deinit()
+
     def deinit(self):
         """Deinitialises the PulseIn and releases any hardware and software
         resources for reuse."""
         # Clean up after ourselves
-        self._process.terminate()
-        procs.remove(self._process)
-        self._mq.remove()
-        queues.remove(self._mq)
+        if self._process is not None:
+            self._process.terminate()
+            if self._process in procs:
+                procs.remove(self._process)
+            self._process = None
+        if self._mq is not None:
+            try:
+                self._mq.remove()
+            except sysv_ipc.ExistentialError:
+                pass  # Already removed
+            if self._mq in queues:
+                queues.remove(self._mq)
+            self._mq = None
 
     def __enter__(self):
         """No-op used by Context Managers."""

--- a/src/adafruit_blinka/microcontroller/generic_linux/libgpiod/libgpiod_chip_1_x.py
+++ b/src/adafruit_blinka/microcontroller/generic_linux/libgpiod/libgpiod_chip_1_x.py
@@ -26,6 +26,11 @@ class Chip:
         else:
             self.num_lines = self.num_lines
 
+    def __del__(self):
+        if self._chip:
+            self._chip.close()
+            self._chip = None
+
     def __repr__(self):
         return self.id
 

--- a/src/adafruit_blinka/microcontroller/generic_linux/libgpiod/libgpiod_chip_2_x.py
+++ b/src/adafruit_blinka/microcontroller/generic_linux/libgpiod/libgpiod_chip_2_x.py
@@ -22,6 +22,11 @@ class Chip:
         info = self._chip.get_info()
         self.num_lines = info.num_lines
 
+    def __del__(self):
+        if self._chip:
+            self._chip.close()
+            self._chip = None
+
     def __repr__(self):
         return self.id
 

--- a/src/adafruit_blinka/microcontroller/generic_linux/libgpiod/libgpiod_pin_1_x.py
+++ b/src/adafruit_blinka/microcontroller/generic_linux/libgpiod/libgpiod_pin_1_x.py
@@ -38,6 +38,9 @@ class Pin:
                 self._chip = gpiod.chip("gpiochip0", gpiod.chip.OPEN_BY_NAME)
         self._line = None
 
+    def __del__(self):
+        self.deinit()
+
     def __repr__(self):
         return str(self.id)
 
@@ -114,6 +117,15 @@ class Pin:
                     self._line.request(config)
             else:
                 raise RuntimeError("Invalid mode for pin: %s" % self.id)
+
+    def deinit(self):
+        """Release the pin and associated resources."""
+        if self._line:
+            self._line.release()
+            self._line = None
+        if self._chip:
+            self._chip.close()
+            self._chip = None
 
     def value(self, val=None):
         """Set or return the Pin Value"""

--- a/src/adafruit_blinka/microcontroller/generic_linux/libgpiod/libgpiod_pin_2_x.py
+++ b/src/adafruit_blinka/microcontroller/generic_linux/libgpiod/libgpiod_pin_2_x.py
@@ -37,8 +37,7 @@ class Pin:
         self._line_request = None
 
     def __del__(self):
-        if self._line_request:
-            self._line_request.release()
+        self.deinit()
 
     def __repr__(self):
         return str(self.id)
@@ -88,6 +87,15 @@ class Pin:
                 )
             else:
                 raise RuntimeError("Invalid mode for pin: %s" % self.id)
+
+    def deinit(self):
+        """Release the pin and associated resources."""
+        if self._line_request:
+            self._line_request.release()
+            self._line_request = None
+        if self._chip:
+            self._chip.close()
+            self._chip = None
 
     def value(self, val=None):
         """Set or return the Pin Value"""

--- a/src/digitalio.py
+++ b/src/digitalio.py
@@ -79,7 +79,10 @@ class DigitalInOut(ContextManaged):
 
     def deinit(self):
         """Deinitialize the Digital Pin"""
-        del self._pin
+        if self._pin is not None:
+            if hasattr(self._pin, "deinit"):
+                self._pin.deinit()
+            self._pin = None
 
     @property
     def direction(self):


### PR DESCRIPTION
## Summary

Fixes #435 — GPIO lines held by libgpiod and PulseIn subprocesses were not being properly released when scripts were interrupted (Ctrl+C, SIGTERM), causing "Unable to set line to input" errors on subsequent runs.

## Problem

When a Python script using Blinka's GPIO or PulseIn is interrupted:

1. **libgpiod 1.x Pin** had no `__del__` or `deinit()` method, so GPIO lines were never released unless `init()` was called again to reconfigure
2. **libgpiod Chip** objects (both 1.x and 2.x) were never explicitly closed
3. **PulseIn subprocesses** relied solely on `atexit` handlers which don't fire on SIGTERM, and the `deinit()` method would crash if called twice
4. **`digitalio.DigitalInOut.deinit()`** just did `del self._pin` which doesn't release GPIO lines on libgpiod 1.x

## Changes

- **libgpiod Pin (1.x & 2.x):** Add `deinit()` method to explicitly release lines and close chips. Add `__del__` as a GC safety net.
- **libgpiod Chip (1.x & 2.x):** Add `__del__` to close chip handles on garbage collection.
- **PulseIn (bcm283x, meson_g12, a311d):** Add `__del__` safety net. Make `deinit()` idempotent (safe to call multiple times). Add SIGTERM signal handler alongside existing `atexit` handler to ensure subprocesses and message queues are cleaned up.
- **digitalio.DigitalInOut:** `deinit()` now calls `pin.deinit()` when available instead of just deleting the reference.